### PR TITLE
smoke tests: add 'defaults const' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/defaults_const/input/ConstantDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/input/ConstantDefaults.lime
@@ -25,15 +25,15 @@ struct ConstantDefaults {
     field2: SomeStruct = StructConstants.dummy4
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 enum AmbiguousEnum {
     DISABLED
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 class AmbiguousConstants {}
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 struct AmbiguousDefaults {
     field1: fire.AmbiguousEnum = fire.AmbiguousEnum.DISABLED
     field2: SomeStruct = fire.AmbiguousConstants.dummy

--- a/gluecodium/src/test/resources/smoke/defaults_const/input/EnumDefaultsExternal.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/input/EnumDefaultsExternal.lime
@@ -32,7 +32,7 @@ class EnumDefaultsExternal {
     }
     struct NullableEnum {
         enumField1: ExternalEnum2? = null
-        enumField1: ExternalEnum2? = ExternalEnum2.DISABLED
+        enumField2: ExternalEnum2? = ExternalEnum2.DISABLED
     }
     typealias EnumAlias = ExternalEnum3
     struct AliasEnum {

--- a/gluecodium/src/test/resources/smoke/defaults_const/input/FireConstants.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/input/FireConstants.lime
@@ -28,11 +28,11 @@ class StructConstants {
 
     @Skip(Swift, Dart)
     const dummy4: SomeStruct = {-1}
-    @Skip(Cpp, Java)
+    @Skip(Cpp, Java, Kotlin)
     const dummy4: SomeStruct = {-2}
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 class AmbiguousConstants {
     const dummy: SomeStruct = {42}
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/input/FireEnums.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/input/FireEnums.lime
@@ -42,6 +42,7 @@ enum ExternalEnum1 {
         cpp include "foo/AlienEnum1.h"
         cpp name "foo::AlienEnum1"
         java name "foo.AlienEnum1"
+        kotlin name "foo.AlienEnum1"
         swift framework "FooKit1"
         dart importPath "package:foo/alien_enum1.dart"
     }
@@ -55,6 +56,7 @@ enum ExternalEnum2 {
         cpp include "foo/AlienEnum2.h"
         cpp name "foo::AlienEnum2"
         java name "foo.AlienEnum2"
+        kotlin name "foo.AlienEnum2"
         swift framework "FooKit2"
         dart importPath "package:foo/alien_enum2.dart"
     }
@@ -68,6 +70,7 @@ enum ExternalEnum3 {
         cpp include "foo/AlienEnum3.h"
         cpp name "foo::AlienEnum3"
         java name "foo.AlienEnum3"
+        kotlin name "foo.AlienEnum3"
         swift framework "FooKit3"
         dart importPath "package:foo/alien_enum3.dart"
     }
@@ -81,6 +84,7 @@ enum ExternalEnum4 {
         cpp include "foo/AlienEnum4.h"
         cpp name "foo::AlienEnum4"
         java name "foo.AlienEnum4"
+        kotlin name "foo.AlienEnum4"
         swift framework "FooKit4"
         dart importPath "package:foo/alien_enum4.dart"
     }
@@ -89,7 +93,7 @@ enum ExternalEnum4 {
     DISABLED
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 enum AmbiguousEnum {
     DISABLED
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/ConstantDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/ConstantDefaults.kt
@@ -1,0 +1,28 @@
+/*
+
+ *
+ */
+
+@file:JvmName("ConstantDefaults")
+
+package com.example.smoke
+
+import com.example.fire.SomeStruct
+
+class ConstantDefaults {
+    @JvmField var field1: SomeStruct
+    @JvmField var field2: SomeStruct
+
+
+
+    constructor() {
+        this.field1 = com.example.fire.StructConstants.DUMMY
+        this.field2 = com.example.fire.StructConstants.DUMMY4
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumCollectionDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumCollectionDefaults.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+@file:JvmName("EnumCollectionDefaults")
+
+package com.example.smoke
+
+import com.example.fire.Enum1
+import com.example.fire.Enum2
+import com.example.fire.Enum3
+import com.example.fire.Enum4
+import java.util.EnumSet
+
+class EnumCollectionDefaults {
+    @JvmField var listField: MutableList<Enum1>
+    @JvmField var setField: MutableSet<Enum2>
+    @JvmField var mapField: MutableMap<Enum3, Enum4>
+
+
+
+    constructor() {
+        this.listField = mutableListOf(Enum1.DISABLED)
+        this.setField = EnumSet.of(Enum2.DISABLED)
+        this.mapField = mutableMapOf(Enum3.DISABLED to Enum4.DISABLED)
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumCollectionDefaultsExternal.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumCollectionDefaultsExternal.kt
@@ -1,0 +1,30 @@
+/*
+
+ *
+ */
+
+@file:JvmName("EnumCollectionDefaultsExternal")
+
+package com.example.smoke
+
+import java.util.EnumSet
+
+class EnumCollectionDefaultsExternal {
+    @JvmField var listField: MutableList<foo.AlienEnum1>
+    @JvmField var setField: MutableSet<foo.AlienEnum2>
+    @JvmField var mapField: MutableMap<foo.AlienEnum3, foo.AlienEnum4>
+
+
+
+    constructor() {
+        this.listField = mutableListOf(foo.AlienEnum1.DISABLED)
+        this.setField = EnumSet.of(foo.AlienEnum2.DISABLED)
+        this.mapField = mutableMapOf(foo.AlienEnum3.DISABLED to foo.AlienEnum4.DISABLED)
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumDefaults.kt
@@ -1,0 +1,101 @@
+/*
+
+ *
+ */
+
+@file:JvmName("EnumDefaults")
+
+package com.example.smoke
+
+import com.example.NativeBase
+import com.example.fire.Enum1
+import com.example.fire.Enum2
+import com.example.fire.Enum3
+import com.example.fire.Enum4
+
+class EnumDefaults : NativeBase {
+
+    class SimpleEnum {
+        @JvmField var enumField: Enum1
+
+
+
+        constructor() {
+            this.enumField = Enum1.DISABLED
+        }
+
+
+
+
+
+    }
+
+    class NullableEnum {
+        @JvmField var enumField1: Enum2?
+        @JvmField var enumField1: Enum2?
+
+
+
+        constructor() {
+            this.enumField1 = null
+            this.enumField1 = Enum2.DISABLED
+        }
+
+
+
+
+
+    }
+
+    class AliasEnum {
+        @JvmField var enumField: Enum3
+
+
+
+        constructor() {
+            this.enumField = Enum3.DISABLED
+        }
+
+
+
+
+
+    }
+
+    class WrappedEnum {
+        @JvmField var structField: EnumWrapper
+
+
+
+        constructor() {
+            this.structField = EnumWrapper(Enum4.DISABLED)
+        }
+
+
+
+
+
+    }
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumDefaultsExternal.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/EnumDefaultsExternal.kt
@@ -1,0 +1,97 @@
+/*
+
+ *
+ */
+
+@file:JvmName("EnumDefaultsExternal")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class EnumDefaultsExternal : NativeBase {
+
+    class SimpleEnum {
+        @JvmField var enumField: foo.AlienEnum1
+
+
+
+        constructor() {
+            this.enumField = foo.AlienEnum1.DISABLED
+        }
+
+
+
+
+
+    }
+
+    class NullableEnum {
+        @JvmField var enumField1: foo.AlienEnum2?
+        @JvmField var enumField2: foo.AlienEnum2?
+
+
+
+        constructor() {
+            this.enumField1 = null
+            this.enumField2 = foo.AlienEnum2.DISABLED
+        }
+
+
+
+
+
+    }
+
+    class AliasEnum {
+        @JvmField var enumField: foo.AlienEnum3
+
+
+
+        constructor() {
+            this.enumField = foo.AlienEnum3.DISABLED
+        }
+
+
+
+
+
+    }
+
+    class WrappedEnum {
+        @JvmField var structField: EnumWrapper
+
+
+
+        constructor() {
+            this.structField = EnumWrapper(foo.AlienEnum4.DISABLED)
+        }
+
+
+
+
+
+    }
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/InternalEnumDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/InternalEnumDefaults.kt
@@ -1,0 +1,31 @@
+/*
+
+ *
+ */
+
+@file:JvmName("InternalEnumDefaults")
+
+package com.example.smoke
+
+
+class InternalEnumDefaults {
+    @JvmField var publicField: FooBarEnum
+    @JvmField var publicListField: MutableList<FooBarEnum>
+    @JvmField var internalField: FooBarEnum
+    @JvmField var internalListField: MutableList<FooBarEnum>
+
+
+
+    constructor() {
+        this.publicField = FooBarEnum.FOO
+        this.publicListField = mutableListOf(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ)
+        this.internalField = FooBarEnum.BAR
+        this.internalListField = mutableListOf(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ)
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/StructWithPosEnums.kt
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android-kotlin/com/example/smoke/StructWithPosEnums.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+@file:JvmName("StructWithPosEnums")
+
+package com.example.smoke
+
+
+class StructWithPosEnums {
+    @JvmField var firstField: SomethingEnum
+    @JvmField var explicitField: SomethingEnum
+    @JvmField var lastField: SomethingEnum
+
+
+
+    constructor() {
+        this.firstField = SomethingEnum.REALLY_FIRST
+        this.explicitField = SomethingEnum.EXPLICIT
+        this.lastField = SomethingEnum.LAST
+    }
+
+
+
+
+
+    companion object {
+        @JvmField final val FIRST_CONSTANT: SomethingEnum = SomethingEnum.REALLY_FIRST
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumDefaultsExternal.java
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumDefaultsExternal.java
@@ -1,42 +1,63 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.example.NativeBase;
+
 public final class EnumDefaultsExternal extends NativeBase {
     public static final class SimpleEnum {
         @NonNull
         public foo.AlienEnum1 enumField;
+
         public SimpleEnum() {
             this.enumField = foo.AlienEnum1.DISABLED;
         }
+
+
     }
+
     public static final class NullableEnum {
         @Nullable
         public foo.AlienEnum2 enumField1;
         @Nullable
-        public foo.AlienEnum2 enumField1;
+        public foo.AlienEnum2 enumField2;
+
         public NullableEnum() {
             this.enumField1 = null;
-            this.enumField1 = foo.AlienEnum2.DISABLED;
+            this.enumField2 = foo.AlienEnum2.DISABLED;
         }
+
+
     }
+
     public static final class AliasEnum {
         @NonNull
         public foo.AlienEnum3 enumField;
+
         public AliasEnum() {
             this.enumField = foo.AlienEnum3.DISABLED;
         }
+
+
     }
+
     public static final class WrappedEnum {
         @NonNull
         public EnumWrapper structField;
+
         public WrappedEnum() {
             this.structField = new EnumWrapper(foo.AlienEnum4.DISABLED);
         }
+
+
     }
+
+
     /**
      * For internal use only.
      * @hidden
@@ -51,5 +72,11 @@ public final class EnumDefaultsExternal extends NativeBase {
             }
         });
     }
+
     private static native void disposeNativeHandle(long nativeHandle);
+
+
+
+
 }
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/EnumDefaultsExternal.h
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/EnumDefaultsExternal.h
@@ -34,10 +34,10 @@ public:
 
     struct _GLUECODIUM_CPP_EXPORT NullableEnum {
         std::optional< foo::AlienEnum2 > enum_field1 = std::optional< foo::AlienEnum2 >();
-        std::optional< foo::AlienEnum2 > enum_field1 = foo::AlienEnum2::DISABLED;
+        std::optional< foo::AlienEnum2 > enum_field2 = foo::AlienEnum2::DISABLED;
 
         NullableEnum( );
-        NullableEnum( std::optional< foo::AlienEnum2 > enum_field1, std::optional< foo::AlienEnum2 > enum_field1 );
+        NullableEnum( std::optional< foo::AlienEnum2 > enum_field1, std::optional< foo::AlienEnum2 > enum_field2 );
 
     };
 

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
@@ -103,11 +103,11 @@ void smokeEnumdefaultsexternalSimpleenumReleaseFfiHandleNullable(Pointer<Void> h
 class EnumDefaultsExternal_NullableEnum {
   alien_enum2.ExternalEnum2? enumField1;
 
-  alien_enum2.ExternalEnum2? enumField1;
+  alien_enum2.ExternalEnum2? enumField2;
 
-  EnumDefaultsExternal_NullableEnum._(this.enumField1, this.enumField1);
+  EnumDefaultsExternal_NullableEnum._(this.enumField1, this.enumField2);
   EnumDefaultsExternal_NullableEnum()
-    : enumField1 = null, enumField1 = alien_enum2.ExternalEnum2.disabled;
+    : enumField1 = null, enumField2 = alien_enum2.ExternalEnum2.disabled;
 }
 
 
@@ -125,33 +125,33 @@ final _smokeEnumdefaultsexternalNullableenumGetFieldenumField1 = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_NullableEnum_get_field_enumField1'));
-final _smokeEnumdefaultsexternalNullableenumGetFieldenumField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumdefaultsexternalNullableenumGetFieldenumField2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EnumDefaultsExternal_NullableEnum_get_field_enumField1'));
+  >('library_smoke_EnumDefaultsExternal_NullableEnum_get_field_enumField2'));
 
 
 
 Pointer<Void> smokeEnumdefaultsexternalNullableenumToFfi(EnumDefaultsExternal_NullableEnum value) {
   final _enumField1Handle = fireExternalenum2ToFfiNullable(value.enumField1);
-  final _enumField1Handle = fireExternalenum2ToFfiNullable(value.enumField1);
-  final _result = _smokeEnumdefaultsexternalNullableenumCreateHandle(_enumField1Handle, _enumField1Handle);
+  final _enumField2Handle = fireExternalenum2ToFfiNullable(value.enumField2);
+  final _result = _smokeEnumdefaultsexternalNullableenumCreateHandle(_enumField1Handle, _enumField2Handle);
   fireExternalenum2ReleaseFfiHandleNullable(_enumField1Handle);
-  fireExternalenum2ReleaseFfiHandleNullable(_enumField1Handle);
+  fireExternalenum2ReleaseFfiHandleNullable(_enumField2Handle);
   return _result;
 }
 
 EnumDefaultsExternal_NullableEnum smokeEnumdefaultsexternalNullableenumFromFfi(Pointer<Void> handle) {
   final _enumField1Handle = _smokeEnumdefaultsexternalNullableenumGetFieldenumField1(handle);
-  final _enumField1Handle = _smokeEnumdefaultsexternalNullableenumGetFieldenumField1(handle);
+  final _enumField2Handle = _smokeEnumdefaultsexternalNullableenumGetFieldenumField2(handle);
   try {
     return EnumDefaultsExternal_NullableEnum._(
       fireExternalenum2FromFfiNullable(_enumField1Handle), 
-      fireExternalenum2FromFfiNullable(_enumField1Handle)
+      fireExternalenum2FromFfiNullable(_enumField2Handle)
     );
   } finally {
     fireExternalenum2ReleaseFfiHandleNullable(_enumField1Handle);
-    fireExternalenum2ReleaseFfiHandleNullable(_enumField1Handle);
+    fireExternalenum2ReleaseFfiHandleNullable(_enumField2Handle);
   }
 }
 
@@ -371,6 +371,7 @@ final _smokeEnumdefaultsexternalReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_release_handle'));
+
 
 
 class EnumDefaultsExternal$Impl extends __lib.NativeBase implements EnumDefaultsExternal {

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/swift/smoke/EnumDefaultsExternal.swift
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/swift/smoke/EnumDefaultsExternal.swift
@@ -1,25 +1,36 @@
 //
+
 //
+
 import Foundation
 import FooKit1
 import FooKit2
 import FooKit3
 import FooKit4
+
 public class EnumDefaultsExternal {
+
     public typealias EnumAlias = ExternalEnum3
+
+
     let c_instance : _baseRef
+
     init(cEnumDefaultsExternal: _baseRef) {
         guard cEnumDefaultsExternal != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cEnumDefaultsExternal
     }
+
     deinit {
         smoke_EnumDefaultsExternal_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_EnumDefaultsExternal_release_handle(c_instance)
     }
+
     public struct SimpleEnum {
+
         public var enumField: ExternalEnum1
+
         public init(enumField: ExternalEnum1 = ExternalEnum1.disabled) {
             self.enumField = enumField
         }
@@ -27,20 +38,27 @@ public class EnumDefaultsExternal {
             enumField = moveFromCType(smoke_EnumDefaultsExternal_SimpleEnum_enumField_get(cHandle))
         }
     }
+
     public struct NullableEnum {
+
         public var enumField1: ExternalEnum2?
-        public var enumField1: ExternalEnum2?
-        public init(enumField1: ExternalEnum2? = nil, enumField1: ExternalEnum2? = ExternalEnum2.disabled) {
+
+        public var enumField2: ExternalEnum2?
+
+        public init(enumField1: ExternalEnum2? = nil, enumField2: ExternalEnum2? = ExternalEnum2.disabled) {
             self.enumField1 = enumField1
-            self.enumField1 = enumField1
+            self.enumField2 = enumField2
         }
         internal init(cHandle: _baseRef) {
             enumField1 = moveFromCType(smoke_EnumDefaultsExternal_NullableEnum_enumField1_get(cHandle))
-            enumField1 = moveFromCType(smoke_EnumDefaultsExternal_NullableEnum_enumField1_get(cHandle))
+            enumField2 = moveFromCType(smoke_EnumDefaultsExternal_NullableEnum_enumField2_get(cHandle))
         }
     }
+
     public struct AliasEnum {
+
         public var enumField: EnumDefaultsExternal.EnumAlias
+
         public init(enumField: EnumDefaultsExternal.EnumAlias = ExternalEnum3.disabled) {
             self.enumField = enumField
         }
@@ -48,8 +66,11 @@ public class EnumDefaultsExternal {
             enumField = moveFromCType(smoke_EnumDefaultsExternal_AliasEnum_enumField_get(cHandle))
         }
     }
+
     public struct WrappedEnum {
+
         public var structField: EnumWrapper
+
         public init(structField: EnumWrapper = EnumWrapper(enumField: ExternalEnum4.disabled)) {
             self.structField = structField
         }
@@ -57,7 +78,12 @@ public class EnumDefaultsExternal {
             structField = moveFromCType(smoke_EnumDefaultsExternal_WrappedEnum_structField_get(cHandle))
         }
     }
+
+
 }
+
+
+
 internal func getRef(_ ref: EnumDefaultsExternal?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
         return RefHolder(0)
@@ -67,6 +93,7 @@ internal func getRef(_ ref: EnumDefaultsExternal?, owning: Bool = true) -> RefHo
         ? RefHolder(ref: handle_copy, release: smoke_EnumDefaultsExternal_release_handle)
         : RefHolder(handle_copy)
 }
+
 extension EnumDefaultsExternal: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -76,11 +103,13 @@ extension EnumDefaultsExternal: Hashable {
     public static func == (lhs: EnumDefaultsExternal, rhs: EnumDefaultsExternal) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+
     /// :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
 }
+
 internal func EnumDefaultsExternal_copyFromCType(_ handle: _baseRef) -> EnumDefaultsExternal {
     if let swift_pointer = smoke_EnumDefaultsExternal_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumDefaultsExternal {
@@ -90,6 +119,7 @@ internal func EnumDefaultsExternal_copyFromCType(_ handle: _baseRef) -> EnumDefa
     smoke_EnumDefaultsExternal_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func EnumDefaultsExternal_moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal {
     if let swift_pointer = smoke_EnumDefaultsExternal_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumDefaultsExternal {
@@ -100,6 +130,7 @@ internal func EnumDefaultsExternal_moveFromCType(_ handle: _baseRef) -> EnumDefa
     smoke_EnumDefaultsExternal_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func EnumDefaultsExternal_copyFromCType(_ handle: _baseRef) -> EnumDefaultsExternal? {
     guard handle != 0 else {
         return nil
@@ -112,18 +143,23 @@ internal func EnumDefaultsExternal_moveFromCType(_ handle: _baseRef) -> EnumDefa
     }
     return EnumDefaultsExternal_moveFromCType(handle) as EnumDefaultsExternal
 }
+
 internal func copyToCType(_ swiftClass: EnumDefaultsExternal) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: EnumDefaultsExternal) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: EnumDefaultsExternal?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: EnumDefaultsExternal?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.SimpleEnum {
     return EnumDefaultsExternal.SimpleEnum(cHandle: handle)
 }
@@ -133,6 +169,7 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.SimpleEn
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.SimpleEnum) -> RefHolder {
     let c_enumField = moveToCType(swiftType.enumField)
     return RefHolder(smoke_EnumDefaultsExternal_SimpleEnum_create_handle(c_enumField.ref))
@@ -153,6 +190,7 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.SimpleEn
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.SimpleEnum?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -163,6 +201,7 @@ internal func copyToCType(_ swiftType: EnumDefaultsExternal.SimpleEnum?) -> RefH
 internal func moveToCType(_ swiftType: EnumDefaultsExternal.SimpleEnum?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EnumDefaultsExternal_SimpleEnum_release_optional_handle)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.NullableEnum {
     return EnumDefaultsExternal.NullableEnum(cHandle: handle)
 }
@@ -172,10 +211,11 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.Nullable
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.NullableEnum) -> RefHolder {
     let c_enumField1 = moveToCType(swiftType.enumField1)
-    let c_enumField1 = moveToCType(swiftType.enumField1)
-    return RefHolder(smoke_EnumDefaultsExternal_NullableEnum_create_handle(c_enumField1.ref, c_enumField1.ref))
+    let c_enumField2 = moveToCType(swiftType.enumField2)
+    return RefHolder(smoke_EnumDefaultsExternal_NullableEnum_create_handle(c_enumField1.ref, c_enumField2.ref))
 }
 internal func moveToCType(_ swiftType: EnumDefaultsExternal.NullableEnum) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EnumDefaultsExternal_NullableEnum_release_handle)
@@ -193,17 +233,19 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.Nullable
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.NullableEnum?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_enumField1 = moveToCType(swiftType.enumField1)
-    let c_enumField1 = moveToCType(swiftType.enumField1)
-    return RefHolder(smoke_EnumDefaultsExternal_NullableEnum_create_optional_handle(c_enumField1.ref, c_enumField1.ref))
+    let c_enumField2 = moveToCType(swiftType.enumField2)
+    return RefHolder(smoke_EnumDefaultsExternal_NullableEnum_create_optional_handle(c_enumField1.ref, c_enumField2.ref))
 }
 internal func moveToCType(_ swiftType: EnumDefaultsExternal.NullableEnum?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EnumDefaultsExternal_NullableEnum_release_optional_handle)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.AliasEnum {
     return EnumDefaultsExternal.AliasEnum(cHandle: handle)
 }
@@ -213,6 +255,7 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.AliasEnu
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.AliasEnum) -> RefHolder {
     let c_enumField = moveToCType(swiftType.enumField)
     return RefHolder(smoke_EnumDefaultsExternal_AliasEnum_create_handle(c_enumField.ref))
@@ -233,6 +276,7 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.AliasEnu
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.AliasEnum?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -243,6 +287,7 @@ internal func copyToCType(_ swiftType: EnumDefaultsExternal.AliasEnum?) -> RefHo
 internal func moveToCType(_ swiftType: EnumDefaultsExternal.AliasEnum?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EnumDefaultsExternal_AliasEnum_release_optional_handle)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.WrappedEnum {
     return EnumDefaultsExternal.WrappedEnum(cHandle: handle)
 }
@@ -252,6 +297,7 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.WrappedE
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.WrappedEnum) -> RefHolder {
     let c_structField = moveToCType(swiftType.structField)
     return RefHolder(smoke_EnumDefaultsExternal_WrappedEnum_create_handle(c_structField.ref))
@@ -272,6 +318,7 @@ internal func moveFromCType(_ handle: _baseRef) -> EnumDefaultsExternal.WrappedE
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: EnumDefaultsExternal.WrappedEnum?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -282,3 +329,6 @@ internal func copyToCType(_ swiftType: EnumDefaultsExternal.WrappedEnum?) -> Ref
 internal func moveToCType(_ swiftType: EnumDefaultsExternal.WrappedEnum?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EnumDefaultsExternal_WrappedEnum_release_optional_handle)
 }
+
+
+


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.