### PR TITLE
functional tests: fix warnings from Kotlin tests

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/RobolectricApplication.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/RobolectricApplication.kt
@@ -58,7 +58,11 @@ class RobolectricApplication : Application() {
         Log.d(TAG, "loadNativeLibraries: Using app library path: " + appLibraryPath)
 
         val files = appLibraryPath.listFiles {
-            dir, name -> name.contains(".so") || name.endsWith(".dylib")
+            _, name -> name.contains(".so") || name.endsWith(".dylib")
+        }
+
+        if (files == null) {
+            throw NullPointerException("loadNativeLibraries: files array is null")
         }
 
         for (sharedObject in files)  {

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerRoundtripTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerRoundtripTest.kt
@@ -29,6 +29,8 @@ class RouteImpl : Route {}
 
 class RouteProviderImpl : RouteProvider {
     override fun setRoute(route: Route) {
+        // Compile time test. Annotation is used to suppress runtime warning.
+        @Suppress("UNUSED_VARIABLE")
         val impl: RouteImpl = route as RouteImpl
     }
 }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/LocalesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/LocalesTest.kt
@@ -73,6 +73,7 @@ class LocalesTest {
     @org.junit.Test
     fun localeWithMalformedLanguage() {
         assertThrows(IllformedLocaleException::class.java) {
+            @Suppress("UNUSED_VARIABLE")
             val locale = Locales.localeWithMalformedLanguage
         }
     }
@@ -80,6 +81,7 @@ class LocalesTest {
     @org.junit.Test
     fun localeWithMalformedCountry() {
         assertThrows(IllformedLocaleException::class.java) {
+            @Suppress("UNUSED_VARIABLE")
             val locale = Locales.localeWithMalformedCountry
         }
     }
@@ -87,6 +89,7 @@ class LocalesTest {
     @org.junit.Test
     fun localeWithMalformedScript() {
         assertThrows(IllformedLocaleException::class.java) {
+            @Suppress("UNUSED_VARIABLE")
             val locale = Locales.localeWithMalformedScript
         }
     }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/MethodOverloadsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/MethodOverloadsTest.kt
@@ -62,12 +62,14 @@ class MethodOverloadsTest {
 
     @org.junit.Test
     fun constructorDoesNotThrow() {
+        @Suppress("UNUSED_VARIABLE")
         val result: ThrowingConstructor = ThrowingConstructor(0.0)
     }
 
     @org.junit.Test
     fun constructorThrows() {
         val exception = assertThrows(ThrowingConstructor.SomeException::class.java) {
+            @Suppress("UNUSED_VARIABLE")
             val result: ThrowingConstructor = ThrowingConstructor(1.0)
         }
 

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/MultipleInheritanceTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/MultipleInheritanceTest.kt
@@ -34,13 +34,13 @@ class MultipleInheritanceTest {
 
         override var childProperty: String
             get() = ""
-            set(value) {}
+            set(_) {}
 
         override fun parentFunction() {}
 
         override var parentProperty: String
             get() = ""
-            set(value) {}
+            set(_) {}
 
         override fun parentFunctionLight(): String {
             return "kotlin face faces"
@@ -48,12 +48,12 @@ class MultipleInheritanceTest {
 
         override var parentPropertyLight: String
             get() = ""
-            set(value) {}
+            set(_) {}
     }
 
     @org.junit.Test
     fun fromCppSendUpcastSucceeds() {
-        val instance: MultiClass = MultipleInheritanceFactory.getMultiClass()
+        val instance: MultiClass? = MultipleInheritanceFactory.getMultiClass()
         assertTrue(instance is NarrowInterface)
     }
 
@@ -119,7 +119,7 @@ class MultipleInheritanceTest {
     }
 
     @org.junit.Test
-    fun fromJavaRoundTripWithUpcastNotEquals() {
+    fun fromKotlinRoundTripWithUpcastNotEquals() {
         val instance: MultiInterface = MultiInterfaceImpl()
 
         assertFalse(instance === MultipleInheritanceFactory.upcastMultiInterfaceToNarrow(instance))

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StructsWithMethodsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StructsWithMethodsTest.kt
@@ -83,12 +83,15 @@ class StructsWithMethodsTest {
     fun vectorCopyConstructorDoesNotThrow() {
         val vector: Vector = Vector(1.0, 2.0)
         val copy = Vector(vector)
+
+        assertEquals(vector, copy)
     }
 
     @org.junit.Test
     fun vectorCopyConstructorThrows() {
         val vector: Vector = Vector(1.0, Double.NaN)
         assertThrows(ValidationUtils.ValidationException::class.java) {
+            @Suppress("UNUSED_VARIABLE")
             val copy = Vector(vector)
         }
     }
@@ -143,12 +146,15 @@ class StructsWithMethodsTest {
     fun vector3CopyConstructorDoesNotThrow() {
         val vector = StructsWithMethodsInterface.Vector3(1.0, 2.0, 3.0)
         val copy = StructsWithMethodsInterface.Vector3(vector)
+
+        assertEquals(vector, copy)
     }
 
     @org.junit.Test
     fun vector3CopyConstructorThrows() {
         val vector = StructsWithMethodsInterface.Vector3(1.0, Double.NaN, 3.0)
         assertThrows(ValidationUtils.ValidationException::class.java) {
+            @Suppress("UNUSED_VARIABLE")
             val copy = StructsWithMethodsInterface.Vector3(vector)
         }
     }


### PR DESCRIPTION
Some files generated warnings related to unused
variables. This mainly happened when the constructor
or function, which was used to create the variable was
throwing an exception.