### PR TITLE
functional tests: fix warnings for Kotlin build

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/DatesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/DatesTest.kt
@@ -44,9 +44,9 @@ class DatesTest {
 
     @org.junit.Test
     fun dateMethodRoundTrip() {
-        val date = Date(1, 3, 5, 7, 9, 11)
         val dateCalendar: Calendar = GregorianCalendar()
-        dateCalendar.setTime(date)
+        dateCalendar.set(1900, 1, 3, 5, 7, 9)
+        val date = dateCalendar.getTime()
 
         val result = Dates.increaseDate(date)
         val resultCalendar = GregorianCalendar()
@@ -68,9 +68,9 @@ class DatesTest {
 
     @org.junit.Test
     fun dateMethodNullableRoundTrip() {
-        val date = Date(1, 3, 5, 7, 9, 11)
         val dateCalendar: Calendar = GregorianCalendar()
-        dateCalendar.setTime(date)
+        dateCalendar.set(1900, 1, 3, 5, 7, 9)
+        val date = dateCalendar.getTime()
 
         val result: Date? = Dates.increaseDateMaybe(date)
         assertNotNull(result)
@@ -88,9 +88,9 @@ class DatesTest {
 
     @org.junit.Test
     fun steadyDateMethodRoundTrip() {
-        val date: Date = Date(1, 3, 5, 7, 9, 11)
         val dateCalendar: Calendar = GregorianCalendar()
-        dateCalendar.setTime(date)
+        dateCalendar.set(1900, 1, 3, 5, 7, 9)
+        val date = dateCalendar.getTime()
 
         val result: Date = DatesSteady.increaseDate(date)
         val resultCalendar: Calendar = GregorianCalendar()
@@ -112,9 +112,9 @@ class DatesTest {
 
     @org.junit.Test
     fun steadyDateMethodNullableRoundTrip() {
-        val date: Date = Date(1, 3, 5, 7, 9, 11)
         val dateCalendar: Calendar = GregorianCalendar()
-        dateCalendar.setTime(date)
+        dateCalendar.set(1900, 1, 3, 5, 7, 9)
+        val date = dateCalendar.getTime()
 
         val result: Date? = DatesSteady.increaseDateMaybe(date)
         assertNotNull(result)

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ColorConverter.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ColorConverter.kt
@@ -32,12 +32,13 @@ object ColorConverter {
     }
 
     @JvmStatic
-    fun convertToInternal(systemColor: Int?): SystemColor {
+    fun convertToInternal(color: Int?): SystemColor {
+        val systemColor: Int = color!!
         return SystemColor(
-            android.graphics.Color.red(systemColor!!) / 255.0f,
-            android.graphics.Color.green(systemColor!!) / 255.0f,
-            android.graphics.Color.blue(systemColor!!) / 255.0f,
-            android.graphics.Color.alpha(systemColor!!) / 255.0f
+            android.graphics.Color.red(systemColor) / 255.0f,
+            android.graphics.Color.green(systemColor) / 255.0f,
+            android.graphics.Color.blue(systemColor) / 255.0f,
+            android.graphics.Color.alpha(systemColor) / 255.0f
         )
     }
 }


### PR DESCRIPTION
The following warning were visible:

 ```
DatesTest.kt:  'constructor Date(Int, Int, Int, Int, Int, Int)' is deprecated.  Deprecated in Java
ColorConverter.kt: Unnecessary non-null assertion (!!) on a non-null receiver of type Int
```