### PR TITLE
Kotlin: suppress unused parameter 'tag' warning

### DIFF
--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -54,7 +54,7 @@
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : {{!!
 }}{{#unlessPredicate "needsDisposer"}}super(nativeHandle, tag){{/unlessPredicate}}{{!!
 }}{{#ifPredicate "needsDisposer"}}super(nativeHandle, { disposeNativeHandle(it) }){{/ifPredicate}} {}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -22,7 +22,7 @@
  * @suppress
  */
 {{resolveName "visibility"}}class {{resolveName}}Impl : NativeBase, {{resolveName}} {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 {{#set override=true classElement=this}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinLazyNativeList.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinLazyNativeList.mustache
@@ -20,7 +20,7 @@
   !}}
 private class {{resolveName}}LazyNativeList : AbstractNativeList<{{resolveName}}> {
 
-    private constructor(nativeHandle: Long, tag: Any?)
+    private constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     override protected external fun obtainSize(): Int

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
@@ -19,7 +19,7 @@ class BasicTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -68,3 +68,4 @@ class BasicTypes : NativeBase {
         @JvmStatic external fun ulongFunction(input: Long) : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -95,7 +95,7 @@ class Comments : NativeBase {
      * @suppress
      */
     class SomeLambdaImpl : NativeBase, SomeLambda {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -152,7 +152,7 @@ class Comments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -276,3 +276,4 @@ class Comments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
@@ -53,7 +53,7 @@ class CommentsLinks : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -114,3 +114,4 @@ class CommentsLinks : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
@@ -45,7 +45,7 @@ class CommentsMarkdown : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -58,3 +58,4 @@ class CommentsMarkdown : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
@@ -28,7 +28,7 @@ class CommentsTable : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -41,3 +41,4 @@ class CommentsTable : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
@@ -28,7 +28,7 @@ class CommentsTableLinks : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -41,3 +41,4 @@ class CommentsTableLinks : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
@@ -18,6 +18,7 @@ class CtorLinks : NativeBase {
 
 
 
+
         constructor() : this(create(), null as Any?) {
             cacheThisInstance();
         }
@@ -28,7 +29,7 @@ class CtorLinks : NativeBase {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         private external fun cacheThisInstance()
@@ -44,10 +45,12 @@ class CtorLinks : NativeBase {
             @JvmStatic external fun create() : Long
         }
     }
+
     /**
      * This class has just one constructor with one argument [com.example.smoke.CtorLinks.SingleCtorWithOneArgument.SingleCtorWithOneArgument].
      */
     class SingleCtorWithOneArgument : NativeBase {
+
 
 
 
@@ -61,7 +64,7 @@ class CtorLinks : NativeBase {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         private external fun cacheThisInstance()
@@ -77,10 +80,12 @@ class CtorLinks : NativeBase {
             @JvmStatic external fun create(arg: Int) : Long
         }
     }
+
     /**
      * This class has just one constructor with two argument [com.example.smoke.CtorLinks.SingleCtorWithTwoArgument.SingleCtorWithTwoArgument].
      */
     class SingleCtorWithTwoArgument : NativeBase {
+
 
 
 
@@ -94,7 +99,7 @@ class CtorLinks : NativeBase {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         private external fun cacheThisInstance()
@@ -110,7 +115,9 @@ class CtorLinks : NativeBase {
             @JvmStatic external fun create(arg: Int, arg2: String) : Long
         }
     }
+
     class OverloadedCtors : NativeBase {
+
 
 
 
@@ -123,6 +130,7 @@ class CtorLinks : NativeBase {
          * @param flag
          */
         @Deprecated("Use [com.example.smoke.CtorLinks.OverloadedCtors.OverloadedCtors] instead.")
+
         constructor(input: String, flag: Boolean) : this(create(input, flag), null as Any?) {
             cacheThisInstance();
         }
@@ -133,7 +141,7 @@ class CtorLinks : NativeBase {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         private external fun cacheThisInstance()
@@ -153,13 +161,14 @@ class CtorLinks : NativeBase {
     }
 
 
+
     /**
      * For internal use only.
      * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -172,3 +181,4 @@ class CtorLinks : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -82,7 +82,7 @@ class ExcludedComments : NativeBase {
      * @suppress
      */
     class SomeLambdaImpl : NativeBase, SomeLambda {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -117,7 +117,7 @@ class ExcludedComments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -158,3 +158,4 @@ class ExcludedComments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
@@ -48,7 +48,7 @@ class ExcludedCommentsOnly : NativeBase {
      * @suppress
      */
     class SomeLambdaImpl : NativeBase, SomeLambda {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -79,7 +79,7 @@ class ExcludedCommentsOnly : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -112,3 +112,4 @@ class ExcludedCommentsOnly : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
@@ -80,7 +80,7 @@ class LambdaComments : NativeBase {
      * @suppress
      */
     class WithNoNamedParametersImpl : NativeBase, WithNoNamedParameters {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -101,7 +101,7 @@ class LambdaComments : NativeBase {
      * @suppress
      */
     class WithNoDocsForParametersImpl : NativeBase, WithNoDocsForParameters {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -122,7 +122,7 @@ class LambdaComments : NativeBase {
      * @suppress
      */
     class WithNamedParametersImpl : NativeBase, WithNamedParameters {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -143,7 +143,7 @@ class LambdaComments : NativeBase {
      * @suppress
      */
     class MixedDocNameParametersImpl : NativeBase, MixedDocNameParameters {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -165,7 +165,7 @@ class LambdaComments : NativeBase {
      * @suppress
      */
     class NoCommentsNoNamedParamsImpl : NativeBase, NoCommentsNoNamedParams {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -182,7 +182,7 @@ class LambdaComments : NativeBase {
      * @suppress
      */
     class NoCommentsWithNamedParamsImpl : NativeBase, NoCommentsWithNamedParams {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -203,7 +203,7 @@ class LambdaComments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -216,3 +216,4 @@ class LambdaComments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
@@ -25,7 +25,7 @@ class LongComments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -46,3 +46,4 @@ class LongComments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
@@ -24,7 +24,7 @@ class MapScene : NativeBase {
      * @suppress
      */
     class LoadSceneCallbackImpl : NativeBase, LoadSceneCallback {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -45,7 +45,7 @@ class MapScene : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -64,3 +64,4 @@ class MapScene : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
@@ -34,7 +34,7 @@ class MultiLineComments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -64,3 +64,4 @@ class MultiLineComments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -47,7 +47,7 @@ class PlatformComments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -84,3 +84,4 @@ class PlatformComments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
@@ -22,7 +22,7 @@ class PlatformCommentsLineBreaks : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -35,3 +35,4 @@ class PlatformCommentsLineBreaks : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
@@ -19,7 +19,7 @@ class UnicodeComments : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -40,3 +40,4 @@ class UnicodeComments : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
@@ -19,7 +19,7 @@ class CollectionConstants : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -36,3 +36,4 @@ class CollectionConstants : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
@@ -23,7 +23,7 @@ class ConstantsInterface : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -43,3 +43,4 @@ class ConstantsInterface : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
@@ -51,7 +51,7 @@ class StructConstants : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -66,3 +66,4 @@ class StructConstants : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
@@ -11,11 +11,9 @@ package com.example.smoke
 class ChildConstructors : Constructors {
 
 
-
     constructor() : this(createNoArgsChild(), null as Any?) {
         cacheThisInstance();
     }
-
     constructor(other: Constructors) : this(createCopyFromParent(other), null as Any?) {
         cacheThisInstance();
     }
@@ -26,7 +24,7 @@ class ChildConstructors : Constructors {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, tag) {}
 
     private external fun cacheThisInstance()
@@ -43,3 +41,4 @@ class ChildConstructors : Constructors {
         @JvmStatic external fun createCopyFromParent(other: Constructors) : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -57,7 +57,7 @@ open class Constructors : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()

--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/Dates.kt
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/Dates.kt
@@ -37,7 +37,7 @@ class Dates : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -64,3 +64,4 @@ class Dates : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
@@ -134,7 +134,7 @@ class DefaultValues : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -150,3 +150,4 @@ class DefaultValues : NativeBase {
         @JvmStatic external fun processStructWithDefaults(input: DefaultValues.StructWithDefaults) : DefaultValues.StructWithDefaults
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
@@ -35,7 +35,7 @@ class DurationMilliseconds : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -58,3 +58,4 @@ class DurationMilliseconds : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
@@ -35,7 +35,7 @@ class DurationSeconds : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -58,3 +58,4 @@ class DurationSeconds : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
@@ -44,7 +44,7 @@ class Enums : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -69,3 +69,4 @@ class Enums : NativeBase {
         @JvmStatic external fun createStructWithEnumInside(type: Enums.InternalErrorCode, message: String) : Enums.ErrorStruct
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
@@ -19,7 +19,7 @@ class EnumsInTypeCollectionInterface : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -35,3 +35,4 @@ class EnumsInTypeCollectionInterface : NativeBase {
         @JvmStatic external fun flipEnumValue(input: EnumsInTypeCollection.TCEnum) : EnumsInTypeCollection.TCEnum
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
@@ -64,7 +64,7 @@ class EquatableClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableInterfaceImpl.kt
@@ -13,7 +13,7 @@ import com.example.NativeBase
  * @suppress
  */
 class EquatableInterfaceImpl : NativeBase, EquatableInterface {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -34,7 +34,7 @@ class Errors : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -62,3 +62,4 @@ class Errors : NativeBase {
         @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
@@ -13,7 +13,7 @@ import com.example.NativeBase
  * @suppress
  */
 class ErrorsInterfaceImpl : NativeBase, ErrorsInterface {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
@@ -23,7 +23,7 @@ class Class : NativeBase, Interface {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()
@@ -46,3 +46,4 @@ class Class : NativeBase, Interface {
         @JvmStatic external fun Constructor() : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalTypes.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalTypes.kt
@@ -19,7 +19,7 @@ class UseKotlinExternalTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -53,3 +53,4 @@ class UseKotlinExternalTypes : NativeBase {
         @JvmStatic external fun veryBooleanUnbox(input: kotlin.Boolean?) : Boolean
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
@@ -27,7 +27,7 @@ class Enums : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -43,3 +43,4 @@ class Enums : NativeBase {
         @JvmStatic external fun methodWithExternalEnum(input: Enums.ExternalEnum) : Unit
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
@@ -37,7 +37,7 @@ class ExternalClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -56,3 +56,4 @@ class ExternalClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterfaceImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 class ExternalInterfaceImpl : NativeBase, ExternalInterface {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun someMethod(someParameter: Byte) : Unit
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
@@ -55,7 +55,7 @@ class Structs : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -74,3 +74,4 @@ class Structs : NativeBase {
         @JvmStatic external fun getAnotherExternalStruct() : Structs.AnotherExternalStruct
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
@@ -38,7 +38,7 @@ class GenericTypesWithBasicTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -81,3 +81,4 @@ class GenericTypesWithBasicTypes : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
@@ -57,7 +57,7 @@ class GenericTypesWithCompoundTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -94,3 +94,4 @@ class GenericTypesWithCompoundTypes : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
@@ -19,7 +19,7 @@ class GenericTypesWithGenericTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -53,3 +53,4 @@ class GenericTypesWithGenericTypes : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
@@ -20,7 +20,7 @@ class UseOptimizedList : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -30,7 +30,7 @@ class UseOptimizedList : NativeBase {
 
     private class UnreasonablyLazyClassLazyNativeList : AbstractNativeList<UnreasonablyLazyClass> {
 
-        private constructor(nativeHandle: Long, tag: Any?)
+        private constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         override protected external fun obtainSize(): Int
@@ -44,7 +44,7 @@ class UseOptimizedList : NativeBase {
 
     private class VeryBigStructLazyNativeList : AbstractNativeList<VeryBigStruct> {
 
-        private constructor(nativeHandle: Long, tag: Any?)
+        private constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         override protected external fun obtainSize(): Int
@@ -67,3 +67,4 @@ class UseOptimizedList : NativeBase {
 
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
@@ -25,7 +25,7 @@ class UseOptimizedListStruct {
 
     private class VeryBigStructLazyNativeList : AbstractNativeList<VeryBigStruct> {
 
-        private constructor(nativeHandle: Long, tag: Any?)
+        private constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         override protected external fun obtainSize(): Int
@@ -39,7 +39,7 @@ class UseOptimizedListStruct {
 
     private class UnreasonablyLazyClassLazyNativeList : AbstractNativeList<UnreasonablyLazyClass> {
 
-        private constructor(nativeHandle: Long, tag: Any?)
+        private constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         override protected external fun obtainSize(): Int

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleClass.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleClass.kt
@@ -19,7 +19,7 @@ class SimpleClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -38,3 +38,4 @@ class SimpleClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterfaceImpl.kt
@@ -13,10 +13,14 @@ import com.example.NativeBase
  * @suppress
  */
 class SimpleInterfaceImpl : NativeBase, SimpleInterface {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
     override external fun getStringValue() : String
+
+
     override external fun useSimpleInterface(input: SimpleInterface) : SimpleInterface
 
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
@@ -52,7 +52,7 @@ class Lambdas : NativeBase {
      * @suppress
      */
     class ProducerImpl : NativeBase, Producer {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -69,7 +69,7 @@ class Lambdas : NativeBase {
      * @suppress
      */
     class ConfounderImpl : NativeBase, Confounder {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         /**
@@ -90,7 +90,7 @@ class Lambdas : NativeBase {
      * @suppress
      */
     class ConsumerImpl : NativeBase, Consumer {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -107,7 +107,7 @@ class Lambdas : NativeBase {
      * @suppress
      */
     class IndexerImpl : NativeBase, Indexer {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -124,7 +124,7 @@ class Lambdas : NativeBase {
      * @suppress
      */
     class NullableConfuserImpl : NativeBase, NullableConfuser {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -145,7 +145,7 @@ class Lambdas : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -164,3 +164,4 @@ class Lambdas : NativeBase {
         @JvmStatic external fun fuse(items: MutableList<String>, callback: Lambdas.Indexer) : MutableMap<Int, String>
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
@@ -11,6 +11,8 @@ import com.example.NativeBase
 
 interface LambdasInterface {
     fun interface TakeScreenshotCallback {
+
+
         fun apply(p0: ByteArray?) : Unit
     }
 
@@ -18,8 +20,10 @@ interface LambdasInterface {
      * @suppress
      */
     class TakeScreenshotCallbackImpl : NativeBase, TakeScreenshotCallback {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
         override external fun apply(p0: ByteArray?) : Unit
 
@@ -29,6 +33,8 @@ interface LambdasInterface {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+
+
 
     fun takeScreenshot(callback: LambdasInterface.TakeScreenshotCallback) : Unit
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducerImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 class StandaloneProducerImpl : NativeBase, StandaloneProducer {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun apply() : String
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
@@ -19,7 +19,7 @@ class Calculator : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -38,3 +38,4 @@ class Calculator : NativeBase {
         @JvmStatic external fun unregisterListener(listener: CalculatorListener) : Unit
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
@@ -13,14 +13,26 @@ import com.example.NativeBase
  * @suppress
  */
 class CalculatorListenerImpl : NativeBase, CalculatorListener {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
     override external fun onCalculationResult(calculationResult: Double) : Unit
+
+
     override external fun onCalculationResultConst(calculationResult: Double) : Unit
+
+
     override external fun onCalculationResultStruct(calculationResult: CalculatorListener.ResultStruct) : Unit
+
+
     override external fun onCalculationResultArray(calculationResult: MutableList<Double>) : Unit
+
+
     override external fun onCalculationResultMap(calculationResults: MutableMap<String, Double>) : Unit
+
+
     override external fun onCalculationResultInstance(calculationResult: CalculationResult) : Unit
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 class InterfaceWithStaticImpl : NativeBase, InterfaceWithStatic {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun regularFunction() : String
 
@@ -26,6 +28,8 @@ class InterfaceWithStaticImpl : NativeBase, InterfaceWithStatic {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun staticFunction() : String
         @JvmStatic var staticProperty: String
             external get

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 internal class InternalListenerImpl : NativeBase, InternalListener {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun onEvent() : Unit
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
@@ -13,19 +13,41 @@ import com.example.NativeBase
  * @suppress
  */
 class ListenerWithNullableImpl : NativeBase, ListenerWithNullable {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
     override external fun methodWithByte(input: Byte?) : Byte?
+
+
     override external fun methodWithUByte(input: Short?) : Short?
+
+
     override external fun methodWithShort(input: Short?) : Short?
+
+
     override external fun methodWithUShort(input: Int?) : Int?
+
+
     override external fun methodWithInt(input: Int?) : Int?
+
+
     override external fun methodWithUInt(input: Long?) : Long?
+
+
     override external fun methodWithLong(input: Long?) : Long?
+
+
     override external fun methodWithULong(input: Long?) : Long?
+
+
     override external fun methodWithDouble(input: Boolean?) : Boolean?
+
+
     override external fun methodWithFloat(input: Float?) : Float?
+
+
     override external fun methodWithDouble(input: Double?) : Double?
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
@@ -13,7 +13,7 @@ import com.example.NativeBase
  * @suppress
  */
 class ListenerWithPropertiesImpl : NativeBase, ListenerWithProperties {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
@@ -13,15 +13,29 @@ import com.example.NativeBase
  * @suppress
  */
 class ListenersWithReturnValuesImpl : NativeBase, ListenersWithReturnValues {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
     override external fun fetchDataDouble() : Double
+
+
     override external fun fetchDataString() : String
+
+
     override external fun fetchDataStruct() : ListenersWithReturnValues.ResultStruct
+
+
     override external fun fetchDataEnum() : ListenersWithReturnValues.ResultEnum
+
+
     override external fun fetchDataArray() : MutableList<Double>
+
+
     override external fun fetchDataMap() : MutableMap<String, Double>
+
+
     override external fun fetchDataInstance() : CalculationResult
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -100,7 +100,7 @@ class Thermometer : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
@@ -35,7 +35,7 @@ class Locales : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -55,3 +55,4 @@ class Locales : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsClassClass.kt
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsClassClass.kt
@@ -18,7 +18,7 @@ class FirstParentIsClassClass : ParentClass, ParentNarrowOne {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, tag) {}
 
 
@@ -42,3 +42,4 @@ class FirstParentIsClassClass : ParentClass, ParentNarrowOne {
 
 
 }
+

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -47,7 +47,7 @@ class NAME_RULES_KT : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()
@@ -78,3 +78,4 @@ class NAME_RULES_KT : NativeBase {
         @JvmStatic external fun create() : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -47,7 +47,7 @@ class LevelOne : NativeBase {
              * @param nativeHandle The handle to resources on C++ side.
              * @param tag Tag used by callers to avoid overload resolution problems.
              */
-            protected constructor(nativeHandle: Long, tag: Any?)
+            protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
                 : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -65,13 +65,14 @@ class LevelOne : NativeBase {
         }
 
 
+
         /**
          * For internal use only.
          * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -86,13 +87,14 @@ class LevelOne : NativeBase {
     }
 
 
+
     /**
      * For internal use only.
      * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -105,3 +107,4 @@ class LevelOne : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
@@ -34,7 +34,7 @@ class NestedReferences : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -50,3 +50,4 @@ class NestedReferences : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
@@ -21,7 +21,7 @@ class OuterClass : NativeBase {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -37,6 +37,7 @@ class OuterClass : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+
     interface InnerInterface {
 
 
@@ -50,7 +51,7 @@ class OuterClass : NativeBase {
      * @suppress
      */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -71,7 +72,7 @@ class OuterClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -87,3 +88,4 @@ class OuterClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
@@ -21,7 +21,7 @@ class OuterClassWithInheritance : ParentClass {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -37,6 +37,7 @@ class OuterClassWithInheritance : ParentClass {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+
     interface InnerInterface {
 
 
@@ -50,7 +51,7 @@ class OuterClassWithInheritance : ParentClass {
      * @suppress
      */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -71,7 +72,7 @@ class OuterClassWithInheritance : ParentClass {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, tag) {}
 
 
@@ -84,3 +85,4 @@ class OuterClassWithInheritance : ParentClass {
 
 
 }
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
@@ -20,7 +20,7 @@ interface OuterInterface {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -36,6 +36,7 @@ interface OuterInterface {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+
     interface InnerInterface {
 
 
@@ -49,7 +50,7 @@ interface OuterInterface {
      * @suppress
      */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -49,7 +49,7 @@ class OuterStruct {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -65,7 +65,9 @@ class OuterStruct {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+
     class Builder : NativeBase {
+
 
 
 
@@ -79,7 +81,7 @@ class OuterStruct {
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
         private external fun cacheThisInstance()
@@ -101,6 +103,7 @@ class OuterStruct {
             @JvmStatic external fun create() : Long
         }
     }
+
     interface InnerInterface {
 
 
@@ -120,7 +123,7 @@ class OuterStruct {
      * @suppress
      */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -137,7 +140,7 @@ class OuterStruct {
      * @suppress
      */
     class InnerLambdaImpl : NativeBase, InnerLambda {
-        protected constructor(nativeHandle: Long, tag: Any?)
+        protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
@@ -20,7 +20,7 @@ class UseFreeTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -36,3 +36,4 @@ class UseFreeTypes : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
@@ -12,7 +12,6 @@ import com.example.NativeBase
 class NoCacheClass : NativeBase {
 
 
-
     constructor() : this(make(), null as Any?) {
     }
 
@@ -22,7 +21,7 @@ class NoCacheClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -40,3 +39,4 @@ class NoCacheClass : NativeBase {
         @JvmStatic external fun make() : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
@@ -98,7 +98,7 @@ class Nullable : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -181,3 +181,4 @@ class Nullable : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
@@ -34,7 +34,7 @@ class NestedPackages : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -50,3 +50,4 @@ class NestedPackages : NativeBase {
         @JvmStatic external fun basicMethod(input: NestedPackages.SomeStruct) : NestedPackages.SomeStruct
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
@@ -19,7 +19,7 @@ class UnderscorePackage : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -35,3 +35,4 @@ class UnderscorePackage : NativeBase {
         @JvmStatic external fun basicMethod(inputString: String) : String
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
@@ -14,7 +14,6 @@ import com.example.smoke.dodoTypes
 class dodoInterface : NativeBase {
 
 
-
     constructor(makeParameter: String) : this(make(makeParameter), null as Any?) {
         cacheThisInstance();
     }
@@ -25,7 +24,7 @@ class dodoInterface : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()
@@ -48,3 +47,4 @@ class dodoInterface : NativeBase {
         @JvmStatic external fun make(makeParameter: String) : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 class dodoListenerImpl : NativeBase, dodoListener {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun DodoMethod(DodoParameter: String) : Unit
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
@@ -19,7 +19,7 @@ class CachedProperties : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -62,3 +62,4 @@ class CachedProperties : NativeBase {
 
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
@@ -38,7 +38,7 @@ class Properties : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -89,3 +89,4 @@ class Properties : NativeBase {
 
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
@@ -13,7 +13,7 @@ import com.example.NativeBase
  * @suppress
  */
 class PropertiesInterfaceImpl : NativeBase, PropertiesInterface {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
@@ -34,7 +34,7 @@ class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -47,3 +47,4 @@ class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
@@ -19,7 +19,7 @@ class EnableIfEnabled : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -53,3 +53,4 @@ class EnableIfEnabled : NativeBase {
         @JvmStatic external fun enableIfMixedList() : Unit
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
@@ -19,7 +19,7 @@ class EnableIfSkipped : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -32,3 +32,4 @@ class EnableIfSkipped : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
@@ -13,13 +13,19 @@ import com.example.NativeBase
  * @suppress
  */
 class InheritFromSkippedImpl : NativeBase, InheritFromSkipped {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
 
+
+
     override external fun notInJava(input: String) : String
+
+
     override external fun notInSwift(input: Boolean) : Boolean
+
+
     override external fun notInDart(input: Float) : Float
     override var skippedInJava: String
         external get

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
@@ -19,7 +19,7 @@ class SkipFunctions : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -41,3 +41,4 @@ class SkipFunctions : NativeBase {
         @JvmStatic external fun notInDart(input: Float) : Float
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
@@ -19,7 +19,7 @@ class SkipTagsOnly : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -32,3 +32,4 @@ class SkipTagsOnly : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
@@ -64,7 +64,7 @@ class SkipTypes : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -77,3 +77,4 @@ class SkipTypes : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
@@ -20,7 +20,7 @@ class SomeSkippedClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -36,3 +36,4 @@ class SomeSkippedClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -208,7 +208,7 @@ class Structs : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -233,3 +233,4 @@ class Structs : NativeBase {
         @JvmStatic external fun modifyAllTypesStruct(input: TypeCollection.AllTypesStruct) : TypeCollection.AllTypesStruct
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
@@ -54,7 +54,7 @@ class StructsWithConstantsInterface : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -67,3 +67,4 @@ class StructsWithConstantsInterface : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -82,7 +82,7 @@ class StructsWithMethodsInterface : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -95,3 +95,4 @@ class StructsWithMethodsInterface : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
@@ -49,7 +49,7 @@ class TypeDefs : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -84,3 +84,4 @@ class TypeDefs : NativeBase {
         @JvmStatic external fun returnTypeDefPointFromTypeCollection(input: TypeCollection.Point) : TypeCollection.Point
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
@@ -19,7 +19,7 @@ internal class InternalClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -35,3 +35,4 @@ internal class InternalClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
@@ -19,7 +19,7 @@ internal class InternalClassInherits : NativeBase, InternalInterfaceParent {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -39,3 +39,4 @@ internal class InternalClassInherits : NativeBase, InternalInterfaceParent {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
@@ -12,11 +12,9 @@ import com.example.NativeBase
 internal class InternalClassWithFunctions : NativeBase {
 
 
-
     constructor() : this(make(), null as Any?) {
         cacheThisInstance();
     }
-
     constructor(foo: String) : this(make(foo), null as Any?) {
         cacheThisInstance();
     }
@@ -27,7 +25,7 @@ internal class InternalClassWithFunctions : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()
@@ -48,3 +46,4 @@ internal class InternalClassWithFunctions : NativeBase {
         @JvmStatic external fun make(foo: String) : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
@@ -19,7 +19,7 @@ internal class InternalClassWithStaticProperty : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -36,3 +36,4 @@ internal class InternalClassWithStaticProperty : NativeBase {
 
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 internal class InternalInterfaceImpl : NativeBase, InternalInterface {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun fooBar() : Unit
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
@@ -13,8 +13,10 @@ import com.example.NativeBase
  * @suppress
  */
 internal class InternalLambdaImpl : NativeBase, InternalLambda {
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
     override external fun apply() : Unit
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
@@ -19,7 +19,7 @@ class InternalPropertyOnly : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -36,3 +36,4 @@ class InternalPropertyOnly : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
@@ -70,7 +70,7 @@ class PublicClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -90,3 +90,4 @@ class PublicClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
@@ -19,7 +19,7 @@ internal class KotlinInternalClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -32,3 +32,4 @@ internal class KotlinInternalClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
@@ -19,7 +19,7 @@ internal class KotlinInternalClassRev : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -32,3 +32,4 @@ internal class KotlinInternalClassRev : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinPublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinPublicClass.kt
@@ -19,7 +19,7 @@ class KotlinPublicClass : NativeBase {
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
-    protected constructor(nativeHandle: Long, tag: Any?)
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
@@ -32,3 +32,4 @@ class KotlinPublicClass : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }
+


### PR DESCRIPTION
The mentioned parameter is used to prevent clashes
with constructors defined by the user. Moreover,
it is used by JNI layer when invoking constructors
to ensure, that the internal one is used.
    
Therefore, the warning was fixed via 'Suppress'
annotation.