### PR TITLE
Kotlin: handle custom attributes

### DIFF
--- a/gluecodium/src/main/resources/templates/kotlin/KotlinAttributes.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinAttributes.mustache
@@ -1,0 +1,25 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#unless noAttributes}}{{#if attributes.kotlin.attribute}}
+{{#attributes.kotlin.attribute}}
+@{{this}}
+{{/attributes.kotlin.attribute}}
+{{/if}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinAttributesInline.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinAttributesInline.mustache
@@ -1,0 +1,21 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if attributes.kotlin.attribute}}{{#attributes.kotlin.attribute}}@{{this}} {{/attributes.kotlin.attribute}}{{/if}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -33,7 +33,7 @@
     {{>kotlinConstructorThrows}}
 constructor({{!!
 }}{{#parameters}}{{!!
-}}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{>kotlin/KotlinAttributesInline}}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}){{!!
 }} : this({{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}), null as Any?) {
 {{#unless classElement.attributes.nocache}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 {{#if this.isOpen}}open {{/if}}class {{resolveName}} : {{!!
 }}{{#if this.parentClass}}{{resolveName this.parentClass "" "ref"}}{{/if}}{{!!
 }}{{#unless this.parentClass}}NativeBase{{/unless}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
@@ -18,5 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 @JvmField final val {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 enum class {{resolveName}}(private val value: Int) {
 {{joinPartial uniqueEnumerators "kotlin/KotlinEnumerator" ",
 "}}{{#if uniqueEnumerators}};{{/if}}{{#if aliasEnumerators}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
@@ -20,6 +20,7 @@
   !}}
 {{#if comment}}
 {{prefixPartial "kotlin/KotlinDocComment" "    "}}{{/if}}{{!!
+}}{{prefixPartial "kotlin/KotlinAttributes" "    "}}{{!!
 }}{{#if isAlias}}    @JvmField val {{resolveName}}{{!!
 }} = {{resolveName value}}{{/if}}{{!!
 }}{{#unless isAlias}}    {{resolveName}}({{resolveName value}}){{/unless}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
@@ -18,6 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 class {{resolveName}}(@JvmField val error: {{resolveName errorType}}) : Exception(error.toString())
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -23,7 +23,7 @@
 {{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
 }}{{#unless isInterface}}external {{/unless}}fun {{resolveName}}({{!!
 }}{{#parameters}}{{!!
-}}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{>kotlin/KotlinAttributesInline}}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}) : {{!!
 }}{{#if isStructure}}{{!!
 }}{{#unless this.isConstructor}}{{resolveName returnType}}{{/unless}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless this.isConstructor}}{{>kotlin/KotlinMethodComment}}{{/unless}}
+{{#unless this.isConstructor}}{{>kotlin/KotlinMethodComment}}{{>kotlin/KotlinAttributes}}{{/unless}}
 {{#thrownType}}@Throws({{resolveName typeRef}}::class){{/thrownType}}
 {{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
 }}{{#unless isInterface}}external {{/unless}}fun {{resolveName}}({{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 interface {{resolveName}} {{!!
 }}{{#if this.parents}}: {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
 {{>kotlin/KotlinContainerContents}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 fun interface {{resolveName}} {
 {{#set isInterface=true noAttributes=true}}{{!!
 }}{{#asFunction}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 {{#if isStatic}}@JvmStatic {{/if}}{{!!
 }}{{#if override}}override {{/if}}{{!!
 }}{{#if setter}}var{{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -18,14 +18,14 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>kotlin/KotlinDocComment}}
+{{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
 class {{resolveName}}{{!!
 }}{{#unless external.kotlin.name}}{{!!
 }}{{#if attributes.serializable}} : Parcelable{{/if}}{{!!
 }}{{/unless}} {
 {{#set isImmutable=attributes.immutable}}
 {{#fields}}
-{{prefixPartial "kotlin/KotlinDocComment" "    "}}{{!!
+{{prefixPartial "kotlin/KotlinDocComment" "    "}}{{prefixPartial "kotlin/KotlinAttributes" "    "}}{{!!
 }}    @JvmField {{!!
 }}{{#unless isImmutable}}var {{/unless}}{{!!
 }}{{#if isImmutable}}val {{/if}}{{!!
@@ -127,6 +127,7 @@ class {{resolveName}}{{!!
      */{{#if attributes.deprecated}}
     @Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
 {{/if}}{{/ifPredicate}}
+{{prefixPartial "kotlin/KotlinAttributes" "    "}}
 {{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
 }}
     constructor({{!!

--- a/gluecodium/src/test/resources/smoke/attributes/input/Attributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/Attributes.lime
@@ -19,27 +19,32 @@ package smoke
 
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
+@Kotlin(Attribute = "OnClass")
 @Swift(Attribute = "OnClass")
 @Dart(Attribute = "OnClass")
 class AttributesClass {
     @Cpp(Attribute = "OnFunctionInClass")
     @Java(Attribute = "OnFunctionInClass")
+    @Kotlin(Attribute = "OnFunctionInClass")
     @Swift(Attribute = "OnFunctionInClass")
     @Dart(Attribute = "OnFunctionInClass")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInClass")
         @Java(Attribute = "OnParameterInClass")
+        @Kotlin(Attribute = "OnParameterInClass")
         @Swift(Attribute = "OnParameterInClass")
         @Dart(Attribute = "OnParameterInClass")
         param: String
     )
     @Cpp(Attribute = "OnPropertyInClass")
     @Java(Attribute = "OnPropertyInClass")
+    @Kotlin(Attribute = "OnPropertyInClass")
     @Swift(Attribute = "OnPropertyInClass")
     @Dart(Attribute = "OnPropertyInClass")
     property prop: String
     @Cpp(Attribute = "OnConstInClass")
     @Java(Attribute = "OnConstInClass")
+    @Kotlin(Attribute = "OnConstInClass")
     @Swift(Attribute = "OnConstInClass")
     @Dart(Attribute = "OnConstInClass")
     const pi: Boolean = false
@@ -47,27 +52,32 @@ class AttributesClass {
 
 @Cpp(Attribute = "OnInterface")
 @Java(Attribute = "OnInterface")
+@Kotlin(Attribute = "OnInterface")
 @Swift(Attribute = "OnInterface")
 @Dart(Attribute = "OnInterface")
 interface AttributesInterface {
     @Cpp(Attribute = "OnFunctionInInterface")
     @Java(Attribute = "OnFunctionInInterface")
+    @Kotlin(Attribute = "OnFunctionInInterface")
     @Swift(Attribute = "OnFunctionInInterface")
     @Dart(Attribute = "OnFunctionInInterface")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInInterface")
         @Java(Attribute = "OnParameterInInterface")
+        @Kotlin(Attribute = "OnParameterInInterface")
         @Swift(Attribute = "OnParameterInInterface")
         @Dart(Attribute = "OnParameterInInterface")
         param: String
     )
     @Cpp(Attribute = "OnPropertyInInterface")
     @Java(Attribute = "OnPropertyInInterface")
+    @Kotlin(Attribute = "OnPropertyInInterface")
     @Swift(Attribute = "OnPropertyInInterface")
     @Dart(Attribute = "OnPropertyInInterface")
     property prop: String
     @Cpp(Attribute = "OnConstInInterface")
     @Java(Attribute = "OnConstInInterface")
+    @Kotlin(Attribute = "OnConstInInterface")
     @Swift(Attribute = "OnConstInInterface")
     @Dart(Attribute = "OnConstInInterface")
     const pi: Boolean = false
@@ -75,27 +85,32 @@ interface AttributesInterface {
 
 @Cpp(Attribute = "OnStruct")
 @Java(Attribute = "OnStruct")
+@Kotlin(Attribute = "OnStruct")
 @Swift(Attribute = "OnStruct")
 @Dart(Attribute = "OnStruct")
 struct AttributesStruct {
     @Cpp(Attribute = "OnField")
     @Java(Attribute = "OnField")
+    @Kotlin(Attribute = "OnField")
     @Swift(Attribute = "OnField")
     @Dart(Attribute = "OnField")
     `field`: String
     @Cpp(Attribute = "OnFunctionInStruct")
     @Java(Attribute = "OnFunctionInStruct")
+    @Kotlin(Attribute = "OnFunctionInStruct")
     @Swift(Attribute = "OnFunctionInStruct")
     @Dart(Attribute = "OnFunctionInStruct")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInStruct")
         @Java(Attribute = "OnParameterInStruct")
+        @Kotlin(Attribute = "OnParameterInStruct")
         @Swift(Attribute = "OnParameterInStruct")
         @Dart(Attribute = "OnParameterInStruct")
         param: String
     )
     @Cpp(Attribute = "OnConstInStruct")
     @Java(Attribute = "OnConstInStruct")
+    @Kotlin(Attribute = "OnConstInStruct")
     @Swift(Attribute = "OnConstInStruct")
     @Dart(Attribute = "OnConstInStruct")
     const pi: Boolean = false
@@ -103,11 +118,13 @@ struct AttributesStruct {
 
 @Cpp(Attribute = "OnEnumeration")
 @Java(Attribute = "OnEnumeration")
+@Kotlin(Attribute = "OnEnumeration")
 @Swift(Attribute = "OnEnumeration")
 @Dart(Attribute = "OnEnumeration")
 enum AttributesEnum {
     @Cpp(Attribute = "OnEnumerator")
     @Java(Attribute = "OnEnumerator")
+    @Kotlin(Attribute = "OnEnumerator")
     @Swift(Attribute = "OnEnumerator")
     @Dart(Attribute = "OnEnumerator")
     NOPE
@@ -115,16 +132,19 @@ enum AttributesEnum {
 
 @Cpp(Attribute = "OnLambda")
 @Java(Attribute = "OnLambda")
+@Kotlin(Attribute = "OnLambda")
 @Swift(Attribute = "OnLambda")
 @Dart(Attribute = "OnLambda")
 lambda AttributesLambda = () -> Void
 
 @Cpp(Attribute = "OnException")
 @Java(Attribute = "OnException")
+@Kotlin(Attribute = "OnException")
 @Swift(Attribute = "OnException")
 @Dart(Attribute = "OnException")
 exception AttributesCrash(String)
 
 @Cpp(Attribute = "OnTypeAlias")
 @Swift(Attribute = "OnTypeAlias")
+@Kotlin(Attribute = "OnTypeAlias")
 typealias AttributesAlias = String

--- a/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
@@ -20,12 +20,14 @@ package smoke
 // Class comment
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
+@Kotlin(Attribute = "OnClass")
 @Swift(Attribute = "OnClass")
 @Dart(Attribute = "OnClass")
 class AttributesWithComments {
     // Function comment
     @Cpp(Attribute = "OnFunctionInClass")
     @Java(Attribute = "OnFunctionInClass")
+    @Kotlin(Attribute = "OnFunctionInClass")
     @Swift(Attribute = "OnFunctionInClass")
     @Dart(Attribute = "OnFunctionInClass")
     fun veryFun()
@@ -34,12 +36,14 @@ class AttributesWithComments {
     // @set Setter comment
     @Cpp(Attribute = "OnPropertyInClass")
     @Java(Attribute = "OnPropertyInClass")
+    @Kotlin(Attribute = "OnPropertyInClass")
     @Swift(Attribute = "OnPropertyInClass")
     @Dart(Attribute = "OnPropertyInClass")
     property prop: String
     // Const comment
     @Cpp(Attribute = "OnConstInClass")
     @Java(Attribute = "OnConstInClass")
+    @Kotlin(Attribute = "OnConstInClass")
     @Swift(Attribute = "OnConstInClass")
     @Dart(Attribute = "OnConstInClass")
     const pi: Boolean = false
@@ -48,6 +52,7 @@ class AttributesWithComments {
         // Field comment
         @Cpp(Attribute = "OnField")
         @Java(Attribute = "OnField")
+        @Kotlin(Attribute = "OnField")
         @Swift(Attribute = "OnField")
         @Dart(Attribute = "OnField")
         `field`: String = ""
@@ -57,24 +62,28 @@ class AttributesWithComments {
 @Deprecated
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
+@Kotlin(Attribute = "OnClass")
 @Swift(Attribute = "OnClass")
 @Dart(Attribute = "OnClass")
 class AttributesWithDeprecated {
     @Deprecated
     @Cpp(Attribute = "OnFunctionInClass")
     @Java(Attribute = "OnFunctionInClass")
+    @Kotlin(Attribute = "OnFunctionInClass")
     @Swift(Attribute = "OnFunctionInClass")
     @Dart(Attribute = "OnFunctionInClass")
     fun veryFun()
     @Deprecated
     @Cpp(Attribute = "OnPropertyInClass")
     @Java(Attribute = "OnPropertyInClass")
+    @Kotlin(Attribute = "OnPropertyInClass")
     @Swift(Attribute = "OnPropertyInClass")
     @Dart(Attribute = "OnPropertyInClass")
     property prop: String { @Deprecated get @Deprecated set }
     @Deprecated
     @Cpp(Attribute = "OnConstInClass")
     @Java(Attribute = "OnConstInClass")
+    @Kotlin(Attribute = "OnConstInClass")
     @Swift(Attribute = "OnConstInClass")
     @Dart(Attribute = "OnConstInClass")
     const pi: Boolean = false
@@ -83,6 +92,7 @@ class AttributesWithDeprecated {
         @Deprecated
         @Cpp(Attribute = "OnField")
         @Java(Attribute = "OnField")
+        @Kotlin(Attribute = "OnField")
         @Swift(Attribute = "OnField")
         @Dart(Attribute = "OnField")
         `field`: String = ""

--- a/gluecodium/src/test/resources/smoke/attributes/input/MultipleAttributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/MultipleAttributes.lime
@@ -17,7 +17,7 @@
 
 package smoke
 
-@Java(Skip) @Swift(Skip) @Dart(Skip)
+@Java(Skip) @Kotlin(Skip) @Swift(Skip) @Dart(Skip)
 class MultipleAttributesCpp {
     @Cpp(Attribute = "Foo")
     @Cpp(Attribute = "Bar")
@@ -37,7 +37,7 @@ class MultipleAttributesCpp {
     fun twoLists()
 }
 
-@Swift(Skip) @Dart(Skip)
+@Swift(Skip) @Kotlin(Skip) @Dart(Skip)
 class MultipleAttributesJava {
     @Java(Attribute = "Foo")
     @Java(Attribute = "Bar")
@@ -57,7 +57,27 @@ class MultipleAttributesJava {
     fun twoLists()
 }
 
-@Java(Skip) @Dart(Skip)
+@Java(Skip) @Swift(Skip) @Dart(Skip)
+class MultipleAttributesKotlin {
+    @Kotlin(Attribute = "Foo")
+    @Kotlin(Attribute = "Bar")
+    fun noLists2()
+    @Kotlin(Attribute = "Foo")
+    @Kotlin(Attribute = "Bar")
+    @Kotlin(Attribute = "Baz")
+    fun noLists3()
+    @Kotlin(Attribute = ["Foo", "Bar"])
+    @Kotlin(Attribute = "Baz")
+    fun listFirst()
+    @Kotlin(Attribute = "Foo")
+    @Kotlin(Attribute = ["Bar", "Baz"])
+    fun listSecond()
+    @Kotlin(Attribute = ["Foo", "Bar"])
+    @Kotlin(Attribute = ["Baz", "Fizz"])
+    fun twoLists()
+}
+
+@Java(Skip) @Kotlin(Skip) @Dart(Skip)
 class MultipleAttributesSwift {
     @Swift(Attribute = "Foo")
     @Swift(Attribute = "Bar")
@@ -77,7 +97,7 @@ class MultipleAttributesSwift {
     fun twoLists()
 }
 
-@Java(Skip) @Swift(Skip)
+@Java(Skip) @Kotlin(Skip) @Swift(Skip)
 class MultipleAttributesDart {
     @Dart(Attribute = "Foo")
     @Dart(Attribute = "Bar")

--- a/gluecodium/src/test/resources/smoke/attributes/input/SpecialAttributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/SpecialAttributes.lime
@@ -20,11 +20,13 @@ package smoke
 class SpecialAttributes {
     @Cpp(Attribute = "Deprecated(\"foo\\nbar\")")
     @Java(Attribute = "Deprecated(\"foo\\nbar\")")
+    @Kotlin(Attribute = "Deprecated(\"foo\\nbar\")")
     @Swift(Attribute = "Deprecated(\"foo\\nbar\")")
     @Dart(Attribute = "Deprecated(\"foo\\nbar\")")
     fun withEscaping()
     @Cpp(Attribute = "HackMe\nrm -rf *")
     @Java(Attribute = "HackMe\nrm -rf *")
+    @Kotlin(Attribute = "HackMe\nrm -rf *")
     @Swift(Attribute = "HackMe\nrm -rf *")
     @Dart(Attribute = "HackMe\nrm -rf *")
     fun withLineBreak()

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
@@ -28,7 +28,7 @@ class AttributesClass : NativeBase {
 
     @OnFunctionInClass
 
-    external fun veryFun(param: String) : Unit
+    external fun veryFun(@OnParameterInClass param: String) : Unit
 
     var prop: String
         external get

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
@@ -37,6 +37,7 @@ class AttributesClass : NativeBase {
 
 
     companion object {
+        @OnConstInClass
         @JvmField final val PI: Boolean = false
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
@@ -9,6 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+@OnClass
 class AttributesClass : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
@@ -1,0 +1,43 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesClass")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class AttributesClass : NativeBase {
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    external fun veryFun(param: String) : Unit
+
+    var prop: String
+        external get
+        external set
+
+
+
+
+    companion object {
+        @JvmField final val PI: Boolean = false
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
@@ -26,6 +26,7 @@ class AttributesClass : NativeBase {
 
 
 
+    @OnFunctionInClass
 
     external fun veryFun(param: String) : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesClass.kt
@@ -30,6 +30,7 @@ class AttributesClass : NativeBase {
 
     external fun veryFun(@OnParameterInClass param: String) : Unit
 
+    @OnPropertyInClass
     var prop: String
         external get
         external set

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesCrashException.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesCrashException.kt
@@ -1,0 +1,13 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesCrash")
+
+package com.example.smoke
+
+
+class AttributesCrashException(@JvmField val error: String) : Exception(error.toString())
+
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesCrashException.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesCrashException.kt
@@ -8,6 +8,7 @@
 package com.example.smoke
 
 
+@OnException
 class AttributesCrashException(@JvmField val error: String) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesEnum.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesEnum.kt
@@ -8,6 +8,8 @@
 package com.example.smoke
 
 
+@OnEnumeration
 enum class AttributesEnum(private val value: Int) {
+    @OnEnumerator
     NOPE(0);
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesEnum.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesEnum.kt
@@ -1,0 +1,13 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesEnum")
+
+package com.example.smoke
+
+
+enum class AttributesEnum(private val value: Int) {
+    NOPE(0);
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
@@ -20,6 +20,7 @@ interface AttributesInterface {
 
 
     companion object {
+        @OnConstInInterface
         @JvmField final val PI: Boolean = false
     }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
@@ -8,6 +8,7 @@
 package com.example.smoke
 
 
+@OnInterface
 interface AttributesInterface {
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
@@ -16,6 +16,7 @@ interface AttributesInterface {
 
     fun veryFun(@OnParameterInInterface param: String) : Unit
 
+    @OnPropertyInInterface
     var prop: String
         get
         set

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
@@ -14,7 +14,7 @@ interface AttributesInterface {
 
     @OnFunctionInInterface
 
-    fun veryFun(param: String) : Unit
+    fun veryFun(@OnParameterInInterface param: String) : Unit
 
     var prop: String
         get

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
@@ -1,0 +1,26 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesInterface")
+
+package com.example.smoke
+
+
+interface AttributesInterface {
+
+
+
+    fun veryFun(param: String) : Unit
+
+    var prop: String
+        get
+        set
+
+
+    companion object {
+        @JvmField final val PI: Boolean = false
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesInterface.kt
@@ -12,6 +12,7 @@ package com.example.smoke
 interface AttributesInterface {
 
 
+    @OnFunctionInInterface
 
     fun veryFun(param: String) : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesLambda.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesLambda.kt
@@ -8,6 +8,7 @@
 package com.example.smoke
 
 
+@OnLambda
 fun interface AttributesLambda {
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesLambda.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesLambda.kt
@@ -1,0 +1,16 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesLambda")
+
+package com.example.smoke
+
+
+fun interface AttributesLambda {
+
+
+    fun apply() : Unit
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
@@ -1,0 +1,31 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesStruct")
+
+package com.example.smoke
+
+
+class AttributesStruct {
+    @JvmField var field: String
+
+
+
+    constructor(field: String) {
+        this.field = field
+    }
+
+
+
+
+
+    external fun veryFun(param: String) : Unit
+
+
+    companion object {
+        @JvmField final val PI: Boolean = false
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
@@ -24,7 +24,7 @@ class AttributesStruct {
 
     @OnFunctionInStruct
 
-    external fun veryFun(param: String) : Unit
+    external fun veryFun(@OnParameterInStruct param: String) : Unit
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
@@ -25,6 +25,7 @@ class AttributesStruct {
 
 
     companion object {
+        @OnConstInStruct
         @JvmField final val PI: Boolean = false
     }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
@@ -8,7 +8,9 @@
 package com.example.smoke
 
 
+@OnStruct
 class AttributesStruct {
+    @OnField
     @JvmField var field: String
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesStruct.kt
@@ -22,6 +22,7 @@ class AttributesStruct {
 
 
 
+    @OnFunctionInStruct
 
     external fun veryFun(param: String) : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
@@ -50,6 +50,7 @@ class AttributesWithComments : NativeBase {
     /**
      * Function comment
      */
+    @OnFunctionInClass
 
     external fun veryFun() : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
@@ -19,6 +19,7 @@ class AttributesWithComments : NativeBase {
         /**
          * Field comment
          */
+        @OnField
         @JvmField var field: String
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
@@ -66,6 +66,7 @@ class AttributesWithComments : NativeBase {
         /**
          * Const comment
          */
+        @OnConstInClass
         @JvmField final val PI: Boolean = false
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
@@ -12,6 +12,7 @@ import com.example.NativeBase
 /**
  * Class comment
  */
+@OnClass
 class AttributesWithComments : NativeBase {
 
     class SomeStruct {

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
@@ -1,0 +1,72 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesWithComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+/**
+ * Class comment
+ */
+class AttributesWithComments : NativeBase {
+
+    class SomeStruct {
+        /**
+         * Field comment
+         */
+        @JvmField var field: String
+
+
+
+        constructor() {
+            this.field = ""
+        }
+
+
+
+
+
+    }
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    /**
+     * Function comment
+     */
+
+    external fun veryFun() : Unit
+
+    /**
+     * Property comment
+     */
+    var prop: String
+        external get
+        external set
+
+
+
+
+    companion object {
+        /**
+         * Const comment
+         */
+        @JvmField final val PI: Boolean = false
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithComments.kt
@@ -57,6 +57,7 @@ class AttributesWithComments : NativeBase {
     /**
      * Property comment
      */
+    @OnPropertyInClass
     var prop: String
         external get
         external set

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
@@ -59,6 +59,7 @@ class AttributesWithDeprecated : NativeBase {
 
     companion object {
         @Deprecated("")
+        @OnConstInClass
         @JvmField final val PI: Boolean = false
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
@@ -1,0 +1,65 @@
+/*
+
+ *
+ */
+
+@file:JvmName("AttributesWithDeprecated")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+@Deprecated("")
+class AttributesWithDeprecated : NativeBase {
+
+    class SomeStruct {
+        @Deprecated("")
+        @JvmField var field: String
+
+
+
+        constructor() {
+            this.field = ""
+        }
+
+
+
+
+
+    }
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    /**
+     *
+     */
+    @Deprecated("")
+
+    external fun veryFun() : Unit
+
+    @Deprecated("")
+    var prop: String
+        external get
+        external set
+
+
+
+
+    companion object {
+        @Deprecated("")
+        @JvmField final val PI: Boolean = false
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
@@ -15,6 +15,7 @@ class AttributesWithDeprecated : NativeBase {
 
     class SomeStruct {
         @Deprecated("")
+        @OnField
         @JvmField var field: String
 
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
@@ -47,6 +47,7 @@ class AttributesWithDeprecated : NativeBase {
      *
      */
     @Deprecated("")
+    @OnFunctionInClass
 
     external fun veryFun() : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
@@ -10,6 +10,7 @@ package com.example.smoke
 import com.example.NativeBase
 
 @Deprecated("")
+@OnClass
 class AttributesWithDeprecated : NativeBase {
 
     class SomeStruct {

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesWithDeprecated.kt
@@ -52,6 +52,7 @@ class AttributesWithDeprecated : NativeBase {
     external fun veryFun() : Unit
 
     @Deprecated("")
+    @OnPropertyInClass
     var prop: String
         external get
         external set

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/MultipleAttributesKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/MultipleAttributesKotlin.kt
@@ -1,0 +1,50 @@
+/*
+
+ *
+ */
+
+@file:JvmName("MultipleAttributesKotlin")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class MultipleAttributesKotlin : NativeBase {
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    external fun noLists2() : Unit
+
+
+    external fun noLists3() : Unit
+
+
+    external fun listFirst() : Unit
+
+
+    external fun listSecond() : Unit
+
+
+    external fun twoLists() : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/MultipleAttributesKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/MultipleAttributesKotlin.kt
@@ -25,18 +25,33 @@ class MultipleAttributesKotlin : NativeBase {
 
 
 
+    @Foo
+    @Bar
 
     external fun noLists2() : Unit
 
+    @Foo
+    @Bar
+    @Baz
 
     external fun noLists3() : Unit
 
+    @Foo
+    @Bar
+    @Baz
 
     external fun listFirst() : Unit
 
+    @Foo
+    @Bar
+    @Baz
 
     external fun listSecond() : Unit
 
+    @Foo
+    @Bar
+    @Baz
+    @Fizz
 
     external fun twoLists() : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/SpecialAttributes.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/SpecialAttributes.kt
@@ -25,9 +25,11 @@ class SpecialAttributes : NativeBase {
 
 
 
+    @Deprecated("foo\nbar")
 
     external fun withEscaping() : Unit
 
+    @HackMerm -rf *
 
     external fun withLineBreak() : Unit
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/SpecialAttributes.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/SpecialAttributes.kt
@@ -1,0 +1,41 @@
+/*
+
+ *
+ */
+
+@file:JvmName("SpecialAttributes")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SpecialAttributes : NativeBase {
+
+
+
+    /**
+     * For internal use only.
+     * @suppress
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    external fun withEscaping() : Unit
+
+
+    external fun withLineBreak() : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}
+


### PR DESCRIPTION
---------- Motivation ----------
Kotlin generator is able to render valid Kotlin files. The handling includes
also all standard attributes/annotations, that are available for Java generator.
This is done to ensure the same level of support for both Kotlin and Java.

However, during implementation one small detail was missed. It is available in Java as:
```
@Java(Attribute=<SOME_CUSTOM_ATTRIBUTE>)
```

---------- Implemented solution ----------
Introduced `KotlinAttributes` and `KotlinAttributesInline` mustache templates and their
usage. The implemented feature is showcased in new case for smoke tests called 'attributes'.