### PR TITLE
Kotlin: align 'async' support with Java

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -8,7 +8,7 @@ Limitations
 
 * This feature is currently *experimental*. There might be bugs and/or breaking changes later.
 * Currently, only works for Dart (with an additional support function generated in C++). `@Async` attribute has no
-effect on Java or Swift.
+effect on Java, Kotlin or Swift.
 * Can be used with instance functions and non-constructor static functions. Cannot be used with constructors,
 properties, or lambdas.
 * Can be used inside classes or structs. Cannot be used in interfaces.
@@ -57,8 +57,8 @@ class AsyncClass {
 ```
 
 >**Note:** if the function or whole type is generated only for C++ and Dart
-> and other platforms are skipped via `@Skip(Java)` and `@Skip(Swift)` then
-> only asynchronous version of the method is generated.
+> and other platforms are skipped via `@Skip(Java)`, `@Skip(Kotlin)` and `@Skip(Swift)`
+> then only asynchronous version of the method is generated.
 
 The first C++ overload is the same as without the `@Async` attribute. It still should be used for synchronous usages in
 Java, Swift, and C++ itself. The second overload is intended for the asynchronous use. This overload does not return any

--- a/functional-tests/functional/input/lime/Async.lime
+++ b/functional-tests/functional/input/lime/Async.lime
@@ -17,19 +17,19 @@
 
 package abc
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 enum AsyncErrorCode {
     NONE,
     BOOM
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 exception Async(AsyncErrorCode)
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 exception ThrowMe(String)
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 class AsyncClass {
     constructor create()
     @Async
@@ -44,7 +44,7 @@ class AsyncClass {
     static fun asyncStatic(input: Boolean)
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 struct AsyncStruct {
     stringField: String
 
@@ -60,7 +60,7 @@ struct AsyncStruct {
     static fun asyncStatic(input: Boolean)
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 class AsyncRenamed {
     @Async
     @Cpp("callDispose")
@@ -71,6 +71,6 @@ class AsyncWithSkips {
     @Skip(Swift) @Skip(Dart)
     static fun make_shared_instance(androidContext: String)
 
-    @Skip(Java) @Async
+    @Skip(Java, Kotlin) @Async
     static fun make_shared_instance()
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
@@ -141,7 +141,7 @@ internal class CppGeneratorPredicates(private val referenceMap: Map<String, Lime
                 if (limeFunction !is LimeFunction) {
                     false
                 } else {
-                    val platforms = listOf(LimeAttributeType.JAVA, LimeAttributeType.SWIFT)
+                    val platforms = listOf(LimeAttributeType.JAVA, LimeAttributeType.KOTLIN, LimeAttributeType.SWIFT)
                     platforms.any { !isSkippedInPlatform(limeFunction, it) }
                 }
             },

--- a/gluecodium/src/test/resources/smoke/async/input/Async.lime
+++ b/gluecodium/src/test/resources/smoke/async/input/Async.lime
@@ -17,18 +17,18 @@
 
 package smoke
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 enum AsyncErrorCode {
     VALUE1 = 1
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 exception Async(AsyncErrorCode)
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 exception ThrowMe(String)
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 class AsyncClass {
     @Async
     fun asyncVoid(input: Boolean)
@@ -42,7 +42,7 @@ class AsyncClass {
     static fun asyncStatic(input: Boolean)
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 struct AsyncStruct {
     stringField: String
 
@@ -58,7 +58,7 @@ struct AsyncStruct {
     static fun asyncStatic(input: Boolean)
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Kotlin, Swift)
 class AsyncRenamed {
     @Async
     @Cpp("callDispose")
@@ -69,6 +69,6 @@ class AsyncWithSkips {
     @Skip(Swift) @Skip(Dart)
     static fun make_shared_instance(androidContext: String)
 
-    @Skip(Java) @Async
+    @Skip(Java, Kotlin) @Async
     static fun make_shared_instance()
 }


### PR DESCRIPTION
Now 'Skip(Kotlin)' is also required to avoid generating
the synchronous version of function. The documentation
is also adjusted.