### PR TITLE
Kotlin: add 'JvmField' annotation to generated enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Bug fixes:
  * **Kotlin**: fixed bug related to redundant generation of properties in `Impl` class for nested lambda.
    Prior to this fix the properties were duplicated and caused compilation problems.
+ * **Kotlin**: added `@JvmField` annotation to `value` field of generated enumerations. Without that annotation
+   the field had to be accessed via getter when Kotlin code was consumed by Java.
 
 ## 13.14.0
 Release date 2025-05-14

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/EnumsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/EnumsTest.java
@@ -117,4 +117,12 @@ public class EnumsTest {
 
     assertTrue(result);
   }
+
+  @Test
+  public void useValueField() {
+    // Note: this test case is used to verify that 'value' field can be accessed
+    // by Java code when running with Kotlin generated code.
+    EnumWithAlias someEnumLabel = EnumWithAlias.FIRST;
+    assertEquals(someEnumLabel.value, EnumWithAlias.ONE.value);
+  }
 }

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
-enum class {{resolveName}}(private val value: Int) {
+enum class {{resolveName}}(@JvmField val value: Int) {
 {{joinPartial uniqueEnumerators "kotlin/KotlinEnumerator" ",
 "}}{{#if uniqueEnumerators}};{{/if}}{{#if aliasEnumerators}}
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesEnum.kt
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android-kotlin/com/example/smoke/AttributesEnum.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 
 @OnEnumeration
-enum class AttributesEnum(private val value: Int) {
+enum class AttributesEnum(@JvmField val value: Int) {
     @OnEnumerator
     NOPE(0);
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -17,7 +17,7 @@ class Comments : NativeBase {
     /**
      * This is some very useful enum.
      */
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         /**
          * Not quite useful
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -15,7 +15,7 @@ interface CommentsInterface {
     /**
      * This is some very useful enum.
      */
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         /**
          * Not quite useful
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -17,7 +17,7 @@ interface DeprecationComments {
      * This is some very useful enum.
      */
     @Deprecated("Unfortunately, this enum is deprecated. Use [com.example.smoke.Comments.SomeEnum] instead.")
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         /**
          * Not quite useful
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -11,7 +11,7 @@ package com.example.smoke
 @Deprecated("Unfortunately, this interface is deprecated.")
 interface DeprecationCommentsOnly {
     @Deprecated("Unfortunately, this enum is deprecated.")
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         @Deprecated("Unfortunately, this item is deprecated.")
         USELESS(0);
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -19,7 +19,7 @@ class ExcludedComments : NativeBase {
      * This is some very useful enum.
      * @suppress
      */
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         /**
          * Not quite useful
          * @suppress

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class ExcludedCommentsOnly : NativeBase {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         USELESS(0);
     }
     class SomethingWrongException(@JvmField val error: ExcludedCommentsOnly.SomeEnum) : Exception(error.toString())

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class PlatformComments : NativeBase {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         USELESS(0),
         USEFUL(1);
     }

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 class Constants {
 
-    enum class StateEnum(private val value: Int) {
+    enum class StateEnum(@JvmField val value: Int) {
         OFF(0),
         ON(1);
     }

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class ConstantsInterface : NativeBase {
 
-    enum class StateEnum(private val value: Int) {
+    enum class StateEnum(@JvmField val value: Int) {
         OFF(0),
         ON(1);
     }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 open class Constructors : NativeBase {
 
-    enum class ErrorEnum(private val value: Int) {
+    enum class ErrorEnum(@JvmField val value: Int) {
         NONE(0),
         CRASHED(1);
     }

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumOptionSet.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumOptionSet.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-enum class EnumOptionSet(private val value: Int) {
+enum class EnumOptionSet(@JvmField val value: Int) {
     ONE(1),
     TWO(2),
     THREE(4);

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-enum class EnumWithAlias(private val value: Int) {
+enum class EnumWithAlias(@JvmField val value: Int) {
     ONE(2),
     TWO(3),
     THREE(4);

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
@@ -11,11 +11,11 @@ import com.example.NativeBase
 
 class Enums : NativeBase {
 
-    enum class SimpleEnum(private val value: Int) {
+    enum class SimpleEnum(@JvmField val value: Int) {
         FIRST(0),
         SECOND(1);
     }
-    enum class InternalErrorCode(private val value: Int) {
+    enum class InternalErrorCode(@JvmField val value: Int) {
         ERROR_NONE(0),
         ERROR_FATAL(999);
     }

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollection.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 class EnumsInTypeCollection {
 
-    enum class TCEnum(private val value: Int) {
+    enum class TCEnum(@JvmField val value: Int) {
         FIRST(0),
         SECOND(1);
     }

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/Equatable.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/Equatable.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 class Equatable {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         FOO(0),
         BAR(1);
     }

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -11,11 +11,11 @@ import com.example.NativeBase
 
 class Errors : NativeBase {
 
-    enum class InternalErrorCode(private val value: Int) {
+    enum class InternalErrorCode(@JvmField val value: Int) {
         ERROR_NONE(0),
         ERROR_FATAL(1);
     }
-    enum class ExternalErrors(private val value: Int) {
+    enum class ExternalErrors(@JvmField val value: Int) {
         NONE(0),
         BOOM(1),
         BUST(2);

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -9,11 +9,11 @@ package com.example.smoke
 
 
 interface ErrorsInterface {
-    enum class InternalError(private val value: Int) {
+    enum class InternalError(@JvmField val value: Int) {
         ERROR_NONE(0),
         ERROR_FATAL(1);
     }
-    enum class ExternalErrors(private val value: Int) {
+    enum class ExternalErrors(@JvmField val value: Int) {
         NONE(0),
         BOOM(1),
         BUST(2);

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 class SomeTypeCollection {
 
-    enum class SomeTypeCollectionError(private val value: Int) {
+    enum class SomeTypeCollectionError(@JvmField val value: Int) {
         ERROR_A(0),
         ERROR_B(1);
     }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Types.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Types.kt
@@ -10,7 +10,7 @@ package com.example.package
 
 class Types {
 
-    enum class Enum(private val value: Int) {
+    enum class Enum(@JvmField val value: Int) {
         NA_N(0);
     }
     class ExceptionException(@JvmField val error: Types.Enum) : Exception(error.toString())

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/Season.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/Season.kt
@@ -8,7 +8,7 @@
 package com.example.kotlinsmoke
 
 
-enum class Season(private val value: Int) {
+enum class Season(@JvmField val value: Int) {
     WINTER(0),
     SPRING(1),
     SUMMER(2),

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
@@ -11,11 +11,11 @@ import com.example.NativeBase
 
 class Enums : NativeBase {
 
-    enum class ExternalEnum(private val value: Int) {
+    enum class ExternalEnum(@JvmField val value: Int) {
         FOO_VALUE(0),
         BAR_VALUE(1);
     }
-    enum class VeryExternalEnum(private val value: Int) {
+    enum class VeryExternalEnum(@JvmField val value: Int) {
         FOO(0),
         BAR(1);
     }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class ExternalClass : NativeBase {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         SOME_VALUE(0);
     }
     class SomeStruct {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterface.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 
 interface ExternalInterface {
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         SOME_VALUE(0);
     }
     class SomeStruct {
@@ -26,6 +26,8 @@ interface ExternalInterface {
 
 
     }
+
+
 
 
     fun someMethod(someParameter: Byte) : Unit

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
@@ -11,11 +11,11 @@ import com.example.NativeBase
 
 class GenericTypesWithCompoundTypes : NativeBase {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         FOO(0),
         BAR(1);
     }
-    enum class ExternalEnum(private val value: Int) {
+    enum class ExternalEnum(@JvmField val value: Int) {
         ON(0),
         OFF(1);
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 
 interface ListenerWithProperties {
-    enum class ResultEnum(private val value: Int) {
+    enum class ResultEnum(@JvmField val value: Int) {
         NONE(0),
         RESULT(1);
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 
 interface ListenersWithReturnValues {
-    enum class ResultEnum(private val value: Int) {
+    enum class ResultEnum(@JvmField val value: Int) {
         NONE(0),
         RESULT(1);
     }
@@ -29,12 +29,26 @@ interface ListenersWithReturnValues {
     }
 
 
+
+
     fun fetchDataDouble() : Double
+
+
     fun fetchDataString() : String
+
+
     fun fetchDataStruct() : ListenersWithReturnValues.ResultStruct
+
+
     fun fetchDataEnum() : ListenersWithReturnValues.ResultEnum
+
+
     fun fetchDataArray() : MutableList<Double>
+
+
     fun fetchDataMap() : MutableMap<String, Double>
+
+
     fun fetchDataInstance() : CalculationResult
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -19,7 +19,7 @@ class Thermometer : NativeBase {
     /**
      * Some error code for thermometer.
      */
-    enum class SomeThermometerErrorCode(private val value: Int) {
+    enum class SomeThermometerErrorCode(@JvmField val value: Int) {
         ERROR_NONE(0),
         ERROR_FATAL(1);
     }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class NAME_RULES_KT : NativeBase {
 
-    enum class EXAMPLE_ERROR_CODE_KT(private val value: Int) {
+    enum class EXAMPLE_ERROR_CODE_KT(@JvmField val value: Int) {
         NONE(0),
         FATAL(1);
     }
@@ -34,6 +34,7 @@ class NAME_RULES_KT : NativeBase {
 
 
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeEnum.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeEnum.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-enum class FreeEnum(private val value: Int) {
+enum class FreeEnum(@JvmField val value: Int) {
     FOO(0),
     BAR(1);
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -15,7 +15,7 @@ class LevelOne : NativeBase {
 
         class LevelThree : NativeBase {
 
-            enum class LevelFourEnum(private val value: Int) {
+            enum class LevelFourEnum(@JvmField val value: Int) {
                 NONE(0);
             }
             class LevelFour {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -14,7 +14,7 @@ import java.util.Locale
 class OuterStruct {
     @JvmField var field: String
 
-    enum class InnerEnum(private val value: Int) {
+    enum class InnerEnum(@JvmField val value: Int) {
         FOO(0),
         BAR(1);
     }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class Nullable : NativeBase {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         ON(0),
         OFF(1);
     }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
@@ -11,11 +11,13 @@ import com.example.smoke.dodoTypes
 
 class dodoTypes {
 
-    enum class dodoEnum(private val value: Int) {
+    enum class dodoEnum(@JvmField val value: Int) {
         DODO_ITEM(0);
     }
     class dodoStruct {
         @JvmField var DODO_FIELD: String
+
+
 
 
 
@@ -30,6 +32,7 @@ class dodoTypes {
 
 
         companion object {
+
             @JvmStatic external fun DodoCreate(DodoParameter: String) : dodoStruct
         }
     }

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class Properties : NativeBase {
 
-    enum class InternalErrorCode(private val value: Int) {
+    enum class InternalErrorCode(@JvmField val value: Int) {
         ERROR_NONE(0),
         ERROR_FATAL(999);
     }

--- a/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
+++ b/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
@@ -13,7 +13,7 @@ import java.util.EnumSet
 
 class Serialization {
 
-    enum class SomeEnum(private val value: Int) {
+    enum class SomeEnum(@JvmField val value: Int) {
         FOO(0),
         BAR(7);
     }

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorAutoTag.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorAutoTag.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-enum class SkipEnumeratorAutoTag(private val value: Int) {
+enum class SkipEnumeratorAutoTag(@JvmField val value: Int) {
     ONE(0),
     THREE(1);
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorExplicitTag.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorExplicitTag.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-enum class SkipEnumeratorExplicitTag(private val value: Int) {
+enum class SkipEnumeratorExplicitTag(@JvmField val value: Int) {
     ZERO(0),
     ONE(3),
     THREE(4);

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class Structs : NativeBase {
 
-    enum class FooBar(private val value: Int) {
+    enum class FooBar(@JvmField val value: Int) {
         FOO(0),
         BAR(1);
     }

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
@@ -11,7 +11,7 @@ import com.example.NativeBase
 
 class PublicClass : NativeBase {
 
-    enum class InternalEnum(private val value: Int) {
+    enum class InternalEnum(@JvmField val value: Int) {
         FOO(0),
         BAR(1);
     }


### PR DESCRIPTION
The annotation was missing in the case of 'value' field
of the generated enumeration. Moreover, the field was
private -- in Java generated code it is public.
    
This commit aligns the behavior of Kotlin generator
with Java generator. Furthermore, it adds a new test case
to functional tests -- it validates that the functionality works.