### PR TITLE
Generate type aliases in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Dart: added support for type aliases (typedefs).
+
 ## 13.15.1
 Release date 2025-06-05
 ### Bug-fixes:

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -70,6 +70,7 @@ import "test/StaticIntMethods_test.dart" as StaticIntMethodsTests;
 import "test/StaticStringMethods_test.dart" as StaticStringMethodsTests;
 import "test/StructsWithConstants_test.dart" as StructsWithConstantsTests;
 import "test/StructsWithMethods_test.dart" as StructsWithMethodsTests;
+import "test/TypeAliases_test.dart" as TypeAliasesTests;
 
 final _allTests = [
   AsyncTests.main,
@@ -119,7 +120,8 @@ final _allTests = [
   StaticIntMethodsTests.main,
   StaticStringMethodsTests.main,
   StructsWithConstantsTests.main,
-  StructsWithMethodsTests.main
+  StructsWithMethodsTests.main,
+  TypeAliasesTests.main
 ];
 
 String _getLibraryPath(String nativeLibraryName) {

--- a/functional-tests/functional/dart/pubspec.yaml.in
+++ b/functional-tests/functional/dart/pubspec.yaml.in
@@ -1,6 +1,6 @@
 name: FunctionalDartTests
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.4.4 <4.0.0'
 dependencies:
   test:
   functional:

--- a/functional-tests/functional/dart/test/TypeAliases_test.dart
+++ b/functional-tests/functional/dart/test/TypeAliases_test.dart
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Type Aliases");
+
+void main() {
+  _testSuite.test("Type alias to struct", () {
+    final result = StaticTypedefExampleStructTypedef("nonsense");
+
+    expect(result is StaticTypedefExampleStruct, isTrue);
+    expect(result.exampleString, "nonsense");
+  });
+  _testSuite.test("Type alias used by a function", () {
+    final result = StaticTypedef.returnIntTypedef(2);
+
+    expect(result is int, isTrue);
+    expect(result, 3);
+  });
+  _testSuite.test("Type alias points to a type alias", () {
+    final result = StaticTypedef.returnNestedIntTypedef(4);
+
+    expect(result is int, isTrue);
+    expect(result, 5);
+  });
+  _testSuite.test("Type alias from type collection", () {
+    final result = StaticTypedef.returnTypedefPointFromTypeCollection(
+        TypeCollectionPointTypedef(1.0, 3.0)
+    );
+
+    expect(result is TypeCollectionPoint, isTrue);
+    expect(result.x, 1.0);
+    expect(result.y, 3.0);
+  });
+}

--- a/functional-tests/functional/input/lime/StaticTypedef.lime
+++ b/functional-tests/functional/input/lime/StaticTypedef.lime
@@ -23,6 +23,10 @@ class StaticTypedef {
     // Example struct
     struct ExampleStruct {
         exampleString: String = ""
+
+        @Skip(Dart)
+        field constructor()
+        field constructor(exampleString)
     }
     typealias IntTypedef = Int
     typealias NestedIntTypedef = IntTypedef

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -195,7 +195,7 @@ internal class DartGenerator : Generator {
 
         val generatedFiles =
             dartFilteredModel.topElements.flatMap {
-                listOfNotNull(
+                listOf(
                     generateDart(
                         it, dartResolvers, dartNameResolver, listOf(importsCollector, declarationImportsCollector),
                         exportsCollector, typeRepositoriesCollector, predicatesMap, descendantInterfaces,
@@ -231,8 +231,8 @@ internal class DartGenerator : Generator {
         predicates: Map<String, (Any) -> Boolean>,
         descendantInterfaces: Map<String, List<LimeInterface>>,
         asyncHelpers: DartAsyncHelpers.AsyncHelpersGroup?,
-    ): GeneratedFile? {
-        val contentTemplateName = selectTemplate(rootElement) ?: return null
+    ): GeneratedFile {
+        val contentTemplateName = selectTemplate(rootElement)
 
         val packagePath = rootElement.path.head.joinToString(separator = "/")
         val fileName = dartNameResolver.resolveFileName(rootElement)
@@ -241,7 +241,7 @@ internal class DartGenerator : Generator {
 
         val isInternal = predicates["isInternal"]!!
 
-        val allTypes = LimeTypeHelper.getAllTypes(rootElement).filterNot { it is LimeTypeAlias }
+        val allTypes = LimeTypeHelper.getAllTypes(rootElement)
         val nonExternalTypes = allTypes.filter { it.external?.dart == null }
         val allSymbols = nonExternalTypes.filterNot { isInternal(it) }
         if (allSymbols.isNotEmpty()) {
@@ -563,7 +563,7 @@ internal class DartGenerator : Generator {
             is LimeEnumeration -> "dart/DartEnumeration"
             is LimeException -> "dart/DartException"
             is LimeLambda -> "dart/DartLambda"
-            is LimeTypeAlias -> null
+            is LimeTypeAlias -> "dart/DartTypeAlias"
             else -> throw GluecodiumExecutionException(
                 "Unsupported top-level element: " +
                     limeElement::class.java.name,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -60,17 +60,16 @@ internal class DartImportResolver(
         limeType: LimeType,
         skipHelpers: Boolean = false,
     ): List<DartImport> {
-        val actualType = limeType.actualType
-        when (actualType) {
-            is LimeBasicType -> return resolveBasicTypeImports(actualType)
-            is LimeGenericType -> return resolveGenericTypeImports(actualType)
+        when (limeType) {
+            is LimeBasicType -> return resolveBasicTypeImports(limeType)
+            is LimeGenericType -> return resolveGenericTypeImports(limeType)
         }
 
-        val externalImport = resolveExternalImport(actualType, IMPORT_PATH_NAME, useAlias = true)
+        val externalImport = resolveExternalImport(limeType, IMPORT_PATH_NAME, useAlias = true)
         return when {
-            externalImport == null -> listOf(createImport(actualType))
+            externalImport == null -> listOf(createImport(limeType))
             skipHelpers -> listOf(externalImport)
-            else -> listOf(createImport(actualType), externalImport)
+            else -> listOf(createImport(limeType), externalImport)
         }
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
@@ -30,6 +30,7 @@ internal class DartImportsCollector(importsResolver: ImportsResolver<DartImport>
         collectTypeRefImports = true,
         collectValueImports = true,
         parentTypeFilter = { true },
+        collectTypeAliasImports = true,
     ) {
     override fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance) =
         when (limeContainer) {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -49,7 +49,6 @@ import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
-import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeValue
@@ -83,7 +82,6 @@ internal class DartNameResolver(
             is LimeValue -> resolveValue(element)
             is LimeGenericType -> resolveGenericType(element)
             is LimeTypeRef -> resolveTypeRefName(element)
-            is LimeTypeAlias -> resolveName(element.typeRef)
             is LimeType -> resolveTypeName(element)
             is LimeNamedElement -> getPlatformName(element)
             else ->
@@ -291,12 +289,12 @@ internal class DartNameResolver(
         ignoreNullability: Boolean = false,
     ): String {
         val typeName = resolveName(limeTypeRef.type)
-        val importPath = limeTypeRef.type.actualType.external?.dart?.get(IMPORT_PATH_NAME)
+        val importPath = limeTypeRef.type.external?.dart?.get(IMPORT_PATH_NAME)
         val alias =
             when {
                 importPath != null -> computeAlias(importPath)
                 ignoreDuplicates -> null
-                duplicateNames.contains(typeName) -> limeTypeRef.type.actualType.path.head.joinToString("_")
+                duplicateNames.contains(typeName) -> limeTypeRef.type.path.head.joinToString("_")
                 else -> null
             }
         val suffix = if (limeTypeRef.isNullable && !ignoreNullability) "?" else ""
@@ -339,7 +337,7 @@ internal class DartNameResolver(
     private fun buildDuplicateNames() =
         limeReferenceMap.values
             .filterIsInstance<LimeType>()
-            .filterNot { it is LimeTypeAlias || it is LimeGenericType || it is LimeBasicType }
+            .filterNot { it is LimeGenericType || it is LimeBasicType }
             .filter { it.external?.dart == null }
             .groupBy { resolveTypeName(it) }
             .filterValues { it.size > 1 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -50,6 +50,9 @@ abstract class {{resolveName}}{{!!
 {{/ifPredicate}}
 }
 
+{{#typeAliases}}
+{{>dart/DartTypeAlias}}
+{{/typeAliases}}
 {{#enumerations}}
 {{>dart/DartEnumeration}}
 {{/enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -66,6 +66,9 @@ abstract class {{resolveName}}{{!!
 {{/ifPredicate}}
 }
 
+{{#typeAliases}}
+{{>dart/DartTypeAlias}}
+{{/typeAliases}}
 {{#enumerations}}
 {{>dart/DartEnumeration}}
 {{/enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -70,6 +70,9 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
 }
 {{/unlessPredicate}}
 
+{{#typeAliases}}
+{{>dart/DartTypeAlias}}
+{{/typeAliases}}
 {{#enumerations}}
 {{>dart/DartEnumeration}}
 {{/enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartTypeAlias.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTypeAlias.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,10 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-name: {{libraryName}}
-environment:
-  sdk: '>=3.4.4 <4.0.0'
-dependencies:
-  ffi:
-  intl:
-  meta:
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
+typedef {{resolveName "visibility"}}{{resolveName}} = {{resolveName typeRef}};

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -11,30 +11,30 @@ import 'package:meta/meta.dart';
 abstract class Comments implements Finalizable {
 
   /// This is some very useful constant.
-  static final bool veryUseful = true;
+  static final Comments_Usefulness veryUseful = true;
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [inputParameter] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
   /// Throws [Comments_SomethingWrongException]. Sometimes it happens.
   ///
-  bool someMethodWithAllComments(String inputParameter);
+  Comments_Usefulness someMethodWithAllComments(String inputParameter);
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  bool someMethodWithInputComments(String input);
+  Comments_Usefulness someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithOutputComments(String input);
+  Comments_Usefulness someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  bool someMethodWithNoComments(String input);
+  Comments_Usefulness someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
   /// [input] Very useful input parameter
@@ -45,12 +45,12 @@ abstract class Comments implements Finalizable {
   void someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithoutInputParametersWithAllComments();
+  Comments_Usefulness someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
   ///
-  bool someMethodWithoutInputParametersWithNoComments();
+  Comments_Usefulness someMethodWithoutInputParametersWithNoComments();
 
   void someMethodWithNothing();
   /// This is some very useful method that does nothing.
@@ -69,13 +69,13 @@ abstract class Comments implements Finalizable {
   /// Note: that's serious.
   /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Gets some very useful property.
-  bool get isSomeProperty;
+  Comments_Usefulness get isSomeProperty;
   /// Some very useful property.
   /// Note: without these comments user may not be able to use it correctly.
   /// Note: that's serious.
   /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Sets some very useful property.
-  set isSomeProperty(bool value);
+  set isSomeProperty(Comments_Usefulness value);
 
   /// OnlyGetterProperty, which does not have a setter.
   /// The generated documentation for this property should only be added to property or getter.
@@ -106,6 +106,8 @@ abstract class Comments implements Finalizable {
 
 }
 
+/// This is some very useful typedef.
+typedef Comments_Usefulness = bool;
 /// This is some very useful enum.
 enum Comments_SomeEnum {
     /// Not quite useful
@@ -183,7 +185,7 @@ class Comments_SomethingWrongException implements Exception {
 class Comments_SomeStruct {
   /// How useful this struct is
   /// remains to be seen
-  bool someField;
+  Comments_Usefulness someField;
 
   /// Can be `null`
   String? nullableField;
@@ -196,7 +198,7 @@ class Comments_SomeStruct {
   /// [nullableField] Can be `null`
 
   Comments_SomeStruct._(this.someField, this.nullableField);
-  Comments_SomeStruct(bool someField)
+  Comments_SomeStruct(Comments_Usefulness someField)
     : someField = someField, nullableField = null;
   /// This is some struct method that does nothing.
   ///
@@ -493,7 +495,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   Comments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String inputParameter) {
+  Comments_Usefulness someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
     final _handle = this.handle;
@@ -520,7 +522,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  bool someMethodWithInputComments(String input) {
+  Comments_Usefulness someMethodWithInputComments(String input) {
     final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -536,7 +538,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  bool someMethodWithOutputComments(String input) {
+  Comments_Usefulness someMethodWithOutputComments(String input) {
     final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -552,7 +554,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  bool someMethodWithNoComments(String input) {
+  Comments_Usefulness someMethodWithNoComments(String input) {
     final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -588,7 +590,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  bool someMethodWithoutInputParametersWithAllComments() {
+  Comments_Usefulness someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -602,7 +604,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  bool someMethodWithoutInputParametersWithNoComments() {
+  Comments_Usefulness someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -666,7 +668,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  bool get isSomeProperty {
+  Comments_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -680,7 +682,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   }
 
   @override
-  set isSomeProperty(bool value) {
+  set isSomeProperty(Comments_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -12,18 +12,18 @@ abstract class CommentsInterface implements Finalizable {
   /// This is some very useful interface.
 
   factory CommentsInterface(
-    bool Function(String) someMethodWithAllCommentsLambda,
-    bool Function(String) someMethodWithInputCommentsLambda,
-    bool Function(String) someMethodWithOutputCommentsLambda,
-    bool Function(String) someMethodWithNoCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithAllCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithInputCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithOutputCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithNoCommentsLambda,
     void Function(String) someMethodWithoutReturnTypeWithAllCommentsLambda,
     void Function(String) someMethodWithoutReturnTypeWithNoCommentsLambda,
-    bool Function() someMethodWithoutInputParametersWithAllCommentsLambda,
-    bool Function() someMethodWithoutInputParametersWithNoCommentsLambda,
+    CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithAllCommentsLambda,
+    CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithNoCommentsLambda,
     void Function() someMethodWithNothingLambda,
     void Function() someMethodWithoutReturnTypeOrInputParametersLambda,
-    bool Function() isSomePropertyGetLambda,
-    void Function(bool) isSomePropertySetLambda
+    CommentsInterface_Usefulness Function() isSomePropertyGetLambda,
+    void Function(CommentsInterface_Usefulness) isSomePropertySetLambda
   ) => CommentsInterface$Lambdas(
     someMethodWithAllCommentsLambda,
     someMethodWithInputCommentsLambda,
@@ -40,28 +40,28 @@ abstract class CommentsInterface implements Finalizable {
   );
 
   /// This is some very useful constant.
-  static final bool veryUseful = true;
+  static final CommentsInterface_Usefulness veryUseful = true;
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithAllComments(String input);
+  CommentsInterface_Usefulness someMethodWithAllComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  bool someMethodWithInputComments(String input);
+  CommentsInterface_Usefulness someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithOutputComments(String input);
+  CommentsInterface_Usefulness someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  bool someMethodWithNoComments(String input);
+  CommentsInterface_Usefulness someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
   /// [input] Very useful input parameter
@@ -72,12 +72,12 @@ abstract class CommentsInterface implements Finalizable {
   void someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithoutInputParametersWithAllComments();
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
   ///
-  bool someMethodWithoutInputParametersWithNoComments();
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithNoComments();
 
   void someMethodWithNothing();
   /// This is some very useful method that does nothing.
@@ -85,13 +85,15 @@ abstract class CommentsInterface implements Finalizable {
   void someMethodWithoutReturnTypeOrInputParameters();
   /// Some very useful property.
   /// Gets some very useful property.
-  bool get isSomeProperty;
+  CommentsInterface_Usefulness get isSomeProperty;
   /// Some very useful property.
   /// Sets some very useful property.
-  set isSomeProperty(bool value);
+  set isSomeProperty(CommentsInterface_Usefulness value);
 
 }
 
+/// This is some very useful typedef.
+typedef CommentsInterface_Usefulness = bool;
 /// This is some very useful enum.
 enum CommentsInterface_SomeEnum {
     /// Not quite useful
@@ -161,7 +163,7 @@ void smokeCommentsinterfaceSomeenumReleaseFfiHandleNullable(Pointer<Void> handle
 
 class CommentsInterface_SomeStruct {
   /// How useful this struct is
-  bool someField;
+  CommentsInterface_Usefulness someField;
 
   CommentsInterface_SomeStruct(this.someField);
 }
@@ -274,18 +276,18 @@ final _smokeCommentsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
 
 
 class CommentsInterface$Lambdas implements CommentsInterface {
-  bool Function(String) someMethodWithAllCommentsLambda;
-  bool Function(String) someMethodWithInputCommentsLambda;
-  bool Function(String) someMethodWithOutputCommentsLambda;
-  bool Function(String) someMethodWithNoCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithAllCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithInputCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithOutputCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithNoCommentsLambda;
   void Function(String) someMethodWithoutReturnTypeWithAllCommentsLambda;
   void Function(String) someMethodWithoutReturnTypeWithNoCommentsLambda;
-  bool Function() someMethodWithoutInputParametersWithAllCommentsLambda;
-  bool Function() someMethodWithoutInputParametersWithNoCommentsLambda;
+  CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithAllCommentsLambda;
+  CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithNoCommentsLambda;
   void Function() someMethodWithNothingLambda;
   void Function() someMethodWithoutReturnTypeOrInputParametersLambda;
-  bool Function() isSomePropertyGetLambda;
-  void Function(bool) isSomePropertySetLambda;
+  CommentsInterface_Usefulness Function() isSomePropertyGetLambda;
+  void Function(CommentsInterface_Usefulness) isSomePropertySetLambda;
 
   CommentsInterface$Lambdas(
     this.someMethodWithAllCommentsLambda,
@@ -303,16 +305,16 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   );
 
   @override
-  bool someMethodWithAllComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
-  bool someMethodWithInputComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithInputComments(String input) =>
     someMethodWithInputCommentsLambda(input);
   @override
-  bool someMethodWithOutputComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithOutputComments(String input) =>
     someMethodWithOutputCommentsLambda(input);
   @override
-  bool someMethodWithNoComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithNoComments(String input) =>
     someMethodWithNoCommentsLambda(input);
   @override
   void someMethodWithoutReturnTypeWithAllComments(String input) =>
@@ -321,10 +323,10 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   void someMethodWithoutReturnTypeWithNoComments(String input) =>
     someMethodWithoutReturnTypeWithNoCommentsLambda(input);
   @override
-  bool someMethodWithoutInputParametersWithAllComments() =>
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithAllComments() =>
     someMethodWithoutInputParametersWithAllCommentsLambda();
   @override
-  bool someMethodWithoutInputParametersWithNoComments() =>
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithNoComments() =>
     someMethodWithoutInputParametersWithNoCommentsLambda();
   @override
   void someMethodWithNothing() =>
@@ -333,9 +335,9 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   void someMethodWithoutReturnTypeOrInputParameters() =>
     someMethodWithoutReturnTypeOrInputParametersLambda();
   @override
-  bool get isSomeProperty => isSomePropertyGetLambda();
+  CommentsInterface_Usefulness get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
+  set isSomeProperty(CommentsInterface_Usefulness value) => isSomePropertySetLambda(value);
 }
 
 class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterface {
@@ -343,7 +345,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   CommentsInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String input) {
+  CommentsInterface_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -359,7 +361,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 
   @override
-  bool someMethodWithInputComments(String input) {
+  CommentsInterface_Usefulness someMethodWithInputComments(String input) {
     final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -375,7 +377,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 
   @override
-  bool someMethodWithOutputComments(String input) {
+  CommentsInterface_Usefulness someMethodWithOutputComments(String input) {
     final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -391,7 +393,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 
   @override
-  bool someMethodWithNoComments(String input) {
+  CommentsInterface_Usefulness someMethodWithNoComments(String input) {
     final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -427,7 +429,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 
   @override
-  bool someMethodWithoutInputParametersWithAllComments() {
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -441,7 +443,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 
   @override
-  bool someMethodWithoutInputParametersWithNoComments() {
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -471,7 +473,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 
   /// Gets some very useful property.
-  bool get isSomeProperty {
+  CommentsInterface_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -488,7 +490,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   ///
   /// [value] Some very useful property.
   ///
-  set isSomeProperty(bool value) {
+  set isSomeProperty(CommentsInterface_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
@@ -502,7 +504,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
 }
 
 void _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(CommentsInterface _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -511,7 +513,7 @@ void _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(CommentsInterface _o
   }
 }
 void _smokeCommentsinterfacesomeMethodWithInputCommentsStatic(CommentsInterface _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithInputComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -520,7 +522,7 @@ void _smokeCommentsinterfacesomeMethodWithInputCommentsStatic(CommentsInterface 
   }
 }
 void _smokeCommentsinterfacesomeMethodWithOutputCommentsStatic(CommentsInterface _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithOutputComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -529,7 +531,7 @@ void _smokeCommentsinterfacesomeMethodWithOutputCommentsStatic(CommentsInterface
   }
 }
 void _smokeCommentsinterfacesomeMethodWithNoCommentsStatic(CommentsInterface _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithNoComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -554,7 +556,7 @@ void _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(Comm
   }
 }
 void _smokeCommentsinterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(CommentsInterface _obj, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithoutInputParametersWithAllComments();
     _result.value = booleanToFfi(_resultObject);
@@ -562,7 +564,7 @@ void _smokeCommentsinterfacesomeMethodWithoutInputParametersWithAllCommentsStati
   }
 }
 void _smokeCommentsinterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(CommentsInterface _obj, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithoutInputParametersWithNoComments();
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -42,8 +42,8 @@ abstract class CommentsLinks implements Finalizable {
   ///   * nested lists
   ///
   /// Not working for Java:
-  /// * typedef: [bool]
-  /// * top level typedef: [bool]
+  /// * typedef: [Comments_Usefulness]
+  /// * top level typedef: [CommentsTypeCollection_TypeCollectionTypedef]
   ///
   /// Not working for Swift:
   /// * named comment: [][Comments.veryUseful]
@@ -182,6 +182,7 @@ final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnHasError = __lib.
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -14,9 +14,9 @@ abstract class DeprecationComments implements Finalizable {
   @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 
   factory DeprecationComments(
-    bool Function(String) someMethodWithAllCommentsLambda,
-    bool Function() isSomePropertyGetLambda,
-    void Function(bool) isSomePropertySetLambda,
+    DeprecationComments_Usefulness Function(String) someMethodWithAllCommentsLambda,
+    DeprecationComments_Usefulness Function() isSomePropertyGetLambda,
+    void Function(DeprecationComments_Usefulness) isSomePropertySetLambda,
     String Function() propertyButNotAccessorsGetLambda,
     void Function(String) propertyButNotAccessorsSetLambda
   ) => DeprecationComments$Lambdas(
@@ -29,25 +29,25 @@ abstract class DeprecationComments implements Finalizable {
 
   /// This is some very useful constant.
   @Deprecated("Unfortunately, this constant is deprecated. Use [Comments.veryUseful] instead.")
-  static final bool veryUseful = true;
+  static final DeprecationComments_Usefulness veryUseful = true;
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [DeprecationComments_Usefulness]. Usefulness of the input
   ///
   @Deprecated("Unfortunately, this method is deprecated.\nUse [Comments.someMethodWithAllComments] instead.")
 
-  bool someMethodWithAllComments(String input);
+  DeprecationComments_Usefulness someMethodWithAllComments(String input);
   /// Some very useful property.
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  bool get isSomeProperty;
+  DeprecationComments_Usefulness get isSomeProperty;
   /// Some very useful property.
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  set isSomeProperty(bool value);
+  set isSomeProperty(DeprecationComments_Usefulness value);
 
   /// Describes the property but not accessors.
   /// Gets the property but not accessors.
@@ -59,6 +59,9 @@ abstract class DeprecationComments implements Finalizable {
 
 }
 
+/// This is some very useful typedef.
+@Deprecated("Unfortunately, this typedef is deprecated. Use [Comments_Usefulness] instead.")
+typedef DeprecationComments_Usefulness = bool;
 /// This is some very useful enum.
 @Deprecated("Unfortunately, this enum is deprecated. Use [Comments_SomeEnum] instead.")
 enum DeprecationComments_SomeEnum {
@@ -131,7 +134,7 @@ class DeprecationComments_SomethingWrongException implements Exception {
 class DeprecationComments_SomeStruct {
   /// How useful this struct is.
   @Deprecated("Unfortunately, this field is deprecated.\nUse [Comments_SomeStruct.someField] instead.")
-  bool someField;
+  DeprecationComments_Usefulness someField;
 
   DeprecationComments_SomeStruct._(this.someField);
   DeprecationComments_SomeStruct()
@@ -237,9 +240,9 @@ final _smokeDeprecationcommentsGetTypeId = __lib.catchArgumentError(() => __lib.
 
 
 class DeprecationComments$Lambdas implements DeprecationComments {
-  bool Function(String) someMethodWithAllCommentsLambda;
-  bool Function() isSomePropertyGetLambda;
-  void Function(bool) isSomePropertySetLambda;
+  DeprecationComments_Usefulness Function(String) someMethodWithAllCommentsLambda;
+  DeprecationComments_Usefulness Function() isSomePropertyGetLambda;
+  void Function(DeprecationComments_Usefulness) isSomePropertySetLambda;
   String Function() propertyButNotAccessorsGetLambda;
   void Function(String) propertyButNotAccessorsSetLambda;
 
@@ -252,12 +255,12 @@ class DeprecationComments$Lambdas implements DeprecationComments {
   );
 
   @override
-  bool someMethodWithAllComments(String input) =>
+  DeprecationComments_Usefulness someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
-  bool get isSomeProperty => isSomePropertyGetLambda();
+  DeprecationComments_Usefulness get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
+  set isSomeProperty(DeprecationComments_Usefulness value) => isSomePropertySetLambda(value);
   @override
   String get propertyButNotAccessors => propertyButNotAccessorsGetLambda();
   @override
@@ -269,7 +272,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String input) {
+  DeprecationComments_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -286,7 +289,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
 
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  bool get isSomeProperty {
+  DeprecationComments_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -305,7 +308,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   ///
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
 
-  set isSomeProperty(bool value) {
+  set isSomeProperty(DeprecationComments_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
@@ -349,7 +352,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
 }
 
 void _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(DeprecationComments _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  DeprecationComments_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -12,9 +12,9 @@ abstract class DeprecationCommentsOnly implements Finalizable {
   @Deprecated("Unfortunately, this interface is deprecated.")
 
   factory DeprecationCommentsOnly(
-    bool Function(String) someMethodWithAllCommentsLambda,
-    bool Function() isSomePropertyGetLambda,
-    void Function(bool) isSomePropertySetLambda
+    DeprecationCommentsOnly_Usefulness Function(String) someMethodWithAllCommentsLambda,
+    DeprecationCommentsOnly_Usefulness Function() isSomePropertyGetLambda,
+    void Function(DeprecationCommentsOnly_Usefulness) isSomePropertySetLambda
   ) => DeprecationCommentsOnly$Lambdas(
     someMethodWithAllCommentsLambda,
     isSomePropertyGetLambda,
@@ -22,23 +22,25 @@ abstract class DeprecationCommentsOnly implements Finalizable {
   );
 
   @Deprecated("Unfortunately, this constant is deprecated.")
-  static final bool veryUseful = true;
+  static final DeprecationCommentsOnly_Usefulness veryUseful = true;
 
 
   /// [input] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [DeprecationCommentsOnly_Usefulness]. Usefulness of the input
   ///
   @Deprecated("Unfortunately, this method is deprecated.")
 
-  bool someMethodWithAllComments(String input);
+  DeprecationCommentsOnly_Usefulness someMethodWithAllComments(String input);
   @Deprecated("Unfortunately, this property's getter is deprecated.")
-  bool get isSomeProperty;
+  DeprecationCommentsOnly_Usefulness get isSomeProperty;
   @Deprecated("Unfortunately, this property's setter is deprecated.")
-  set isSomeProperty(bool value);
+  set isSomeProperty(DeprecationCommentsOnly_Usefulness value);
 
 }
 
+@Deprecated("Unfortunately, this typedef is deprecated.")
+typedef DeprecationCommentsOnly_Usefulness = bool;
 @Deprecated("Unfortunately, this enum is deprecated.")
 enum DeprecationCommentsOnly_SomeEnum {
     @Deprecated("Unfortunately, this item is deprecated.")
@@ -102,7 +104,7 @@ void smokeDeprecationcommentsonlySomeenumReleaseFfiHandleNullable(Pointer<Void> 
 
 class DeprecationCommentsOnly_SomeStruct {
   @Deprecated("Unfortunately, this field is deprecated.")
-  bool someField;
+  DeprecationCommentsOnly_Usefulness someField;
 
   DeprecationCommentsOnly_SomeStruct._(this.someField);
   DeprecationCommentsOnly_SomeStruct()
@@ -208,9 +210,9 @@ final _smokeDeprecationcommentsonlyGetTypeId = __lib.catchArgumentError(() => __
 
 
 class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
-  bool Function(String) someMethodWithAllCommentsLambda;
-  bool Function() isSomePropertyGetLambda;
-  void Function(bool) isSomePropertySetLambda;
+  DeprecationCommentsOnly_Usefulness Function(String) someMethodWithAllCommentsLambda;
+  DeprecationCommentsOnly_Usefulness Function() isSomePropertyGetLambda;
+  void Function(DeprecationCommentsOnly_Usefulness) isSomePropertySetLambda;
 
   DeprecationCommentsOnly$Lambdas(
     this.someMethodWithAllCommentsLambda,
@@ -219,12 +221,12 @@ class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
   );
 
   @override
-  bool someMethodWithAllComments(String input) =>
+  DeprecationCommentsOnly_Usefulness someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
-  bool get isSomeProperty => isSomePropertyGetLambda();
+  DeprecationCommentsOnly_Usefulness get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
+  set isSomeProperty(DeprecationCommentsOnly_Usefulness value) => isSomePropertySetLambda(value);
 }
 
 class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
@@ -232,7 +234,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String input) {
+  DeprecationCommentsOnly_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -248,7 +250,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
   }
 
   @Deprecated("Unfortunately, this property's getter is deprecated.")
-  bool get isSomeProperty {
+  DeprecationCommentsOnly_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -264,7 +266,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
 
   @Deprecated("Unfortunately, this property's setter is deprecated.")
 
-  set isSomeProperty(bool value) {
+  set isSomeProperty(DeprecationCommentsOnly_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
@@ -278,7 +280,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
 }
 
 void _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(DeprecationCommentsOnly _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  DeprecationCommentsOnly_Usefulness? _resultObject;
   try {
     _resultObject = _obj.someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -12,18 +12,18 @@ abstract class ExcludedComments implements Finalizable {
 
   /// This is some very useful constant.
   /// @nodoc
-  static final bool veryUseful = true;
+  static final ExcludedComments_Usefulness veryUseful = true;
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [inputParameter] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [ExcludedComments_Usefulness]. Usefulness of the input
   ///
   /// Throws [ExcludedComments_SomethingWrongException]. Sometimes it happens.
   ///
   /// @nodoc
-  bool someMethodWithAllComments(String inputParameter);
+  ExcludedComments_Usefulness someMethodWithAllComments(String inputParameter);
   /// This is some very useful method that does nothing.
   ///
   /// @nodoc
@@ -31,14 +31,17 @@ abstract class ExcludedComments implements Finalizable {
   /// Some very useful property.
   /// Gets some very useful property.
   /// @nodoc
-  bool get isSomeProperty;
+  ExcludedComments_Usefulness get isSomeProperty;
   /// Some very useful property.
   /// Sets some very useful property.
   /// @nodoc
-  set isSomeProperty(bool value);
+  set isSomeProperty(ExcludedComments_Usefulness value);
 
 }
 
+/// This is some very useful typealias.
+/// @nodoc
+typedef ExcludedComments_Usefulness = bool;
 /// This is some very useful enum.
 /// @nodoc
 enum ExcludedComments_SomeEnum {
@@ -113,7 +116,7 @@ class ExcludedComments_SomeStruct {
   /// How useful this struct is
   /// remains to be seen
   /// @nodoc
-  bool someField;
+  ExcludedComments_Usefulness someField;
 
   /// This is how easy it is to construct.
 
@@ -369,7 +372,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String inputParameter) {
+  ExcludedComments_Usefulness someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
     final _handle = this.handle;
@@ -404,7 +407,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   }
 
   @override
-  bool get isSomeProperty {
+  ExcludedComments_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -418,7 +421,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   }
 
   @override
-  set isSomeProperty(bool value) {
+  set isSomeProperty(ExcludedComments_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -10,21 +10,23 @@ import 'package:library/src/builtin_types__conversion.dart';
 abstract class ExcludedCommentsOnly implements Finalizable {
 
   /// @nodoc
-  static final bool veryUseful = true;
+  static final ExcludedCommentsOnly_Usefulness veryUseful = true;
 
 
   /// @nodoc
-  bool someMethodWithAllComments(String inputParameter);
+  ExcludedCommentsOnly_Usefulness someMethodWithAllComments(String inputParameter);
 
   /// @nodoc
   void someMethodWithoutReturnTypeOrInputParameters();
   /// @nodoc
-  bool get isSomeProperty;
+  ExcludedCommentsOnly_Usefulness get isSomeProperty;
   /// @nodoc
-  set isSomeProperty(bool value);
+  set isSomeProperty(ExcludedCommentsOnly_Usefulness value);
 
 }
 
+/// @nodoc
+typedef ExcludedCommentsOnly_Usefulness = bool;
 /// @nodoc
 enum ExcludedCommentsOnly_SomeEnum {
     /// @nodoc
@@ -93,7 +95,7 @@ class ExcludedCommentsOnly_SomethingWrongException implements Exception {
 
 class ExcludedCommentsOnly_SomeStruct {
   /// @nodoc
-  bool someField;
+  ExcludedCommentsOnly_Usefulness someField;
 
   ExcludedCommentsOnly_SomeStruct(this.someField);
 }
@@ -337,7 +339,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String inputParameter) {
+  ExcludedCommentsOnly_Usefulness someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
     final _handle = this.handle;
@@ -372,7 +374,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   }
 
   @override
-  bool get isSomeProperty {
+  ExcludedCommentsOnly_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -386,7 +388,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   }
 
   @override
-  set isSomeProperty(bool value) {
+  set isSomeProperty(ExcludedCommentsOnly_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -13,11 +13,11 @@ abstract class UnicodeComments implements Finalizable {
   ///
   /// [input] שלום
   ///
-  /// Returns [bool]. товарищ
+  /// Returns [Comments_Usefulness]. товарищ
   ///
   /// Throws [Comments_SomethingWrongException]. ネコ
   ///
-  bool someMethodWithAllComments(String input);
+  Comments_Usefulness someMethodWithAllComments(String input);
 }
 
 
@@ -55,12 +55,13 @@ final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStr
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
 
 
+
 class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
 
   UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String input) {
+  Comments_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/generic_types__conversion.dart
@@ -1,6 +1,12 @@
+
+
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/dates_steady.dart';
+
 import 'dart:ffi';
+
 import 'package:library/src/_library_context.dart' as __lib;
+
 final _foobarListofDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -33,6 +39,7 @@ final _foobarListofDateIteratorGet = __lib.catchArgumentError(() => __lib.native
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_Date_iterator_get'));
+
 Pointer<Void> foobarListofDateToFfi(List<DateTime> value) {
   final _result = _foobarListofDateCreateHandle();
   for (final element in value) {
@@ -42,6 +49,7 @@ Pointer<Void> foobarListofDateToFfi(List<DateTime> value) {
   }
   return _result;
 }
+
 List<DateTime> foobarListofDateFromFfi(Pointer<Void> handle) {
   final result = List<DateTime>.empty(growable: true);
   final _iteratorHandle = _foobarListofDateIterator(handle);
@@ -57,7 +65,9 @@ List<DateTime> foobarListofDateFromFfi(Pointer<Void> handle) {
   _foobarListofDateIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
+
 void foobarListofDateReleaseFfiHandle(Pointer<Void> handle) => _foobarListofDateReleaseHandle(handle);
+
 final _foobarListofDateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -70,6 +80,7 @@ final _foobarListofDateGetValueNullable = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Date_get_value_nullable'));
+
 Pointer<Void> foobarListofDateToFfiNullable(List<DateTime>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarListofDateToFfi(value);
@@ -77,6 +88,7 @@ Pointer<Void> foobarListofDateToFfiNullable(List<DateTime>? value) {
   foobarListofDateReleaseFfiHandle(_handle);
   return result;
 }
+
 List<DateTime>? foobarListofDateFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarListofDateGetValueNullable(handle);
@@ -84,8 +96,10 @@ List<DateTime>? foobarListofDateFromFfiNullable(Pointer<Void> handle) {
   foobarListofDateReleaseFfiHandle(_handle);
   return result;
 }
+
 void foobarListofDateReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _foobarListofDateReleaseHandleNullable(handle);
+
 final _foobarListofDateStd2chrono2steady1clock2time1pointCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -118,7 +132,8 @@ final _foobarListofDateStd2chrono2steady1clock2time1pointIteratorGet = __lib.cat
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_Date_std_2chrono_2steady_1clock_2time_1point_iterator_get'));
-Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfi(List<DateTime> value) {
+
+Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfi(List<DatesSteady_MonotonicDate> value) {
   final _result = _foobarListofDateStd2chrono2steady1clock2time1pointCreateHandle();
   for (final element in value) {
     final _elementHandle = dateToFfi(element);
@@ -127,8 +142,9 @@ Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfi(List<DateT
   }
   return _result;
 }
-List<DateTime> foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(Pointer<Void> handle) {
-  final result = List<DateTime>.empty(growable: true);
+
+List<DatesSteady_MonotonicDate> foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(Pointer<Void> handle) {
+  final result = List<DatesSteady_MonotonicDate>.empty(growable: true);
   final _iteratorHandle = _foobarListofDateStd2chrono2steady1clock2time1pointIterator(handle);
   while (_foobarListofDateStd2chrono2steady1clock2time1pointIteratorIsValid(handle, _iteratorHandle) != 0) {
     final _elementHandle = _foobarListofDateStd2chrono2steady1clock2time1pointIteratorGet(_iteratorHandle);
@@ -142,7 +158,9 @@ List<DateTime> foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(Pointer
   _foobarListofDateStd2chrono2steady1clock2time1pointIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
+
 void foobarListofDateStd2chrono2steady1clock2time1pointReleaseFfiHandle(Pointer<Void> handle) => _foobarListofDateStd2chrono2steady1clock2time1pointReleaseHandle(handle);
+
 final _foobarListofDateStd2chrono2steady1clock2time1pointCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -155,22 +173,26 @@ final _foobarListofDateStd2chrono2steady1clock2time1pointGetValueNullable = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Date_std_2chrono_2steady_1clock_2time_1point_get_value_nullable'));
-Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfiNullable(List<DateTime>? value) {
+
+Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfiNullable(List<DatesSteady_MonotonicDate>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarListofDateStd2chrono2steady1clock2time1pointToFfi(value);
   final result = _foobarListofDateStd2chrono2steady1clock2time1pointCreateHandleNullable(_handle);
   foobarListofDateStd2chrono2steady1clock2time1pointReleaseFfiHandle(_handle);
   return result;
 }
-List<DateTime>? foobarListofDateStd2chrono2steady1clock2time1pointFromFfiNullable(Pointer<Void> handle) {
+
+List<DatesSteady_MonotonicDate>? foobarListofDateStd2chrono2steady1clock2time1pointFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarListofDateStd2chrono2steady1clock2time1pointGetValueNullable(handle);
   final result = foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(_handle);
   foobarListofDateStd2chrono2steady1clock2time1pointReleaseFfiHandle(_handle);
   return result;
 }
+
 void foobarListofDateStd2chrono2steady1clock2time1pointReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _foobarListofDateStd2chrono2steady1clock2time1pointReleaseHandleNullable(handle);
+
 final _foobarMapofDateStd2chrono2steady1clock2time1pointToStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -207,7 +229,8 @@ final _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorGetValue
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Date_std_2chrono_2steady_1clock_2time_1point_to_String_iterator_get_value'));
-Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(Map<DateTime, String> value) {
+
+Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(Map<DatesSteady_MonotonicDate, String> value) {
   final _result = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringCreateHandle();
   for (final entry in value.entries) {
     final _keyHandle = dateToFfi(entry.key);
@@ -218,8 +241,9 @@ Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(Map
   }
   return _result;
 }
-Map<DateTime, String> foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfi(Pointer<Void> handle) {
-  final result = Map<DateTime, String>();
+
+Map<DatesSteady_MonotonicDate, String> foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfi(Pointer<Void> handle) {
+  final result = Map<DatesSteady_MonotonicDate, String>();
   final _iteratorHandle = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIterator(handle);
   while (_foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorIsValid(handle, _iteratorHandle) != 0) {
     final _keyHandle = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorGetKey(_iteratorHandle);
@@ -236,7 +260,9 @@ Map<DateTime, String> foobarMapofDateStd2chrono2steady1clock2time1pointToStringF
   _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
+
 void foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseFfiHandle(Pointer<Void> handle) => _foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseHandle(handle);
+
 final _foobarMapofDateStd2chrono2steady1clock2time1pointToStringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -249,22 +275,26 @@ final _foobarMapofDateStd2chrono2steady1clock2time1pointToStringGetValueNullable
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Date_std_2chrono_2steady_1clock_2time_1point_to_String_get_value_nullable'));
-Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfiNullable(Map<DateTime, String>? value) {
+
+Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfiNullable(Map<DatesSteady_MonotonicDate, String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(value);
   final result = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringCreateHandleNullable(_handle);
   foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseFfiHandle(_handle);
   return result;
 }
-Map<DateTime, String>? foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfiNullable(Pointer<Void> handle) {
+
+Map<DatesSteady_MonotonicDate, String>? foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringGetValueNullable(handle);
   final result = foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfi(_handle);
   foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseFfiHandle(_handle);
   return result;
 }
+
 void foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseHandleNullable(handle);
+
 final _foobarMapofStringToDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -301,6 +331,7 @@ final _foobarMapofStringToDateIteratorGetValue = __lib.catchArgumentError(() => 
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_Date_iterator_get_value'));
+
 Pointer<Void> foobarMapofStringToDateToFfi(Map<String, DateTime> value) {
   final _result = _foobarMapofStringToDateCreateHandle();
   for (final entry in value.entries) {
@@ -312,6 +343,7 @@ Pointer<Void> foobarMapofStringToDateToFfi(Map<String, DateTime> value) {
   }
   return _result;
 }
+
 Map<String, DateTime> foobarMapofStringToDateFromFfi(Pointer<Void> handle) {
   final result = Map<String, DateTime>();
   final _iteratorHandle = _foobarMapofStringToDateIterator(handle);
@@ -330,7 +362,9 @@ Map<String, DateTime> foobarMapofStringToDateFromFfi(Pointer<Void> handle) {
   _foobarMapofStringToDateIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
+
 void foobarMapofStringToDateReleaseFfiHandle(Pointer<Void> handle) => _foobarMapofStringToDateReleaseHandle(handle);
+
 final _foobarMapofStringToDateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -343,6 +377,7 @@ final _foobarMapofStringToDateGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_Date_get_value_nullable'));
+
 Pointer<Void> foobarMapofStringToDateToFfiNullable(Map<String, DateTime>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarMapofStringToDateToFfi(value);
@@ -350,6 +385,7 @@ Pointer<Void> foobarMapofStringToDateToFfiNullable(Map<String, DateTime>? value)
   foobarMapofStringToDateReleaseFfiHandle(_handle);
   return result;
 }
+
 Map<String, DateTime>? foobarMapofStringToDateFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarMapofStringToDateGetValueNullable(handle);
@@ -357,8 +393,10 @@ Map<String, DateTime>? foobarMapofStringToDateFromFfiNullable(Pointer<Void> hand
   foobarMapofStringToDateReleaseFfiHandle(_handle);
   return result;
 }
+
 void foobarMapofStringToDateReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _foobarMapofStringToDateReleaseHandleNullable(handle);
+
 final _foobarSetofDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -391,6 +429,7 @@ final _foobarSetofDateIteratorGet = __lib.catchArgumentError(() => __lib.nativeL
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_SetOf_Date_iterator_get'));
+
 Pointer<Void> foobarSetofDateToFfi(Set<DateTime> value) {
   final _result = _foobarSetofDateCreateHandle();
   for (final element in value) {
@@ -400,6 +439,7 @@ Pointer<Void> foobarSetofDateToFfi(Set<DateTime> value) {
   }
   return _result;
 }
+
 Set<DateTime> foobarSetofDateFromFfi(Pointer<Void> handle) {
   final result = Set<DateTime>();
   final _iteratorHandle = _foobarSetofDateIterator(handle);
@@ -415,7 +455,9 @@ Set<DateTime> foobarSetofDateFromFfi(Pointer<Void> handle) {
   _foobarSetofDateIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
+
 void foobarSetofDateReleaseFfiHandle(Pointer<Void> handle) => _foobarSetofDateReleaseHandle(handle);
+
 final _foobarSetofDateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -428,6 +470,7 @@ final _foobarSetofDateGetValueNullable = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Date_get_value_nullable'));
+
 Pointer<Void> foobarSetofDateToFfiNullable(Set<DateTime>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarSetofDateToFfi(value);
@@ -435,6 +478,7 @@ Pointer<Void> foobarSetofDateToFfiNullable(Set<DateTime>? value) {
   foobarSetofDateReleaseFfiHandle(_handle);
   return result;
 }
+
 Set<DateTime>? foobarSetofDateFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarSetofDateGetValueNullable(handle);
@@ -442,5 +486,7 @@ Set<DateTime>? foobarSetofDateFromFfiNullable(Pointer<Void> handle) {
   foobarSetofDateReleaseFfiHandle(_handle);
   return result;
 }
+
 void foobarSetofDateReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _foobarSetofDateReleaseHandleNullable(handle);
+

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults_aliased.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults_aliased.dart
@@ -1,16 +1,28 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/date_alias.dart';
+
+
 class DateDefaultsAliased {
-  DateTime dateTime;
-  DateTime dateTimeUtc;
-  DateTime beforeEpoch;
-  DateTime exactlyEpoch;
+  DateAlias dateTime;
+
+  DateAlias dateTimeUtc;
+
+  DateAlias beforeEpoch;
+
+  DateAlias exactlyEpoch;
+
   DateDefaultsAliased._(this.dateTime, this.dateTimeUtc, this.beforeEpoch, this.exactlyEpoch);
   DateDefaultsAliased()
     : dateTime = DateTime.fromMillisecondsSinceEpoch(1643966117000), dateTimeUtc = DateTime.fromMillisecondsSinceEpoch(1643966117000), beforeEpoch = DateTime.fromMillisecondsSinceEpoch(-1511793883000), exactlyEpoch = DateTime.fromMillisecondsSinceEpoch(0);
 }
+
+
 // DateDefaultsAliased "private" section, not exported.
+
 final _smokeDatedefaultsaliasedCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Uint64, Uint64, Uint64),
     Pointer<Void> Function(int, int, int, int)
@@ -35,6 +47,9 @@ final _smokeDatedefaultsaliasedGetFieldexactlyEpoch = __lib.catchArgumentError((
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DateDefaultsAliased_get_field_exactlyEpoch'));
+
+
+
 Pointer<Void> smokeDatedefaultsaliasedToFfi(DateDefaultsAliased value) {
   final _dateTimeHandle = dateToFfi(value.dateTime);
   final _dateTimeUtcHandle = dateToFfi(value.dateTimeUtc);
@@ -47,6 +62,7 @@ Pointer<Void> smokeDatedefaultsaliasedToFfi(DateDefaultsAliased value) {
   dateReleaseFfiHandle(_exactlyEpochHandle);
   return _result;
 }
+
 DateDefaultsAliased smokeDatedefaultsaliasedFromFfi(Pointer<Void> handle) {
   final _dateTimeHandle = _smokeDatedefaultsaliasedGetFielddateTime(handle);
   final _dateTimeUtcHandle = _smokeDatedefaultsaliasedGetFielddateTimeUtc(handle);
@@ -54,9 +70,9 @@ DateDefaultsAliased smokeDatedefaultsaliasedFromFfi(Pointer<Void> handle) {
   final _exactlyEpochHandle = _smokeDatedefaultsaliasedGetFieldexactlyEpoch(handle);
   try {
     return DateDefaultsAliased._(
-      dateFromFfi(_dateTimeHandle),
-      dateFromFfi(_dateTimeUtcHandle),
-      dateFromFfi(_beforeEpochHandle),
+      dateFromFfi(_dateTimeHandle), 
+      dateFromFfi(_dateTimeUtcHandle), 
+      dateFromFfi(_beforeEpochHandle), 
       dateFromFfi(_exactlyEpochHandle)
     );
   } finally {
@@ -66,8 +82,11 @@ DateDefaultsAliased smokeDatedefaultsaliasedFromFfi(Pointer<Void> handle) {
     dateReleaseFfiHandle(_exactlyEpochHandle);
   }
 }
+
 void smokeDatedefaultsaliasedReleaseFfiHandle(Pointer<Void> handle) => _smokeDatedefaultsaliasedReleaseHandle(handle);
+
 // Nullable DateDefaultsAliased
+
 final _smokeDatedefaultsaliasedCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -80,6 +99,7 @@ final _smokeDatedefaultsaliasedGetValueNullable = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DateDefaultsAliased_get_value_nullable'));
+
 Pointer<Void> smokeDatedefaultsaliasedToFfiNullable(DateDefaultsAliased? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDatedefaultsaliasedToFfi(value);
@@ -87,6 +107,7 @@ Pointer<Void> smokeDatedefaultsaliasedToFfiNullable(DateDefaultsAliased? value) 
   smokeDatedefaultsaliasedReleaseFfiHandle(_handle);
   return result;
 }
+
 DateDefaultsAliased? smokeDatedefaultsaliasedFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDatedefaultsaliasedGetValueNullable(handle);
@@ -94,6 +115,10 @@ DateDefaultsAliased? smokeDatedefaultsaliasedFromFfiNullable(Pointer<Void> handl
   smokeDatedefaultsaliasedReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDatedefaultsaliasedReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDatedefaultsaliasedReleaseHandleNullable(handle);
+
 // End of DateDefaultsAliased "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -21,6 +21,9 @@ abstract class Dates implements Finalizable {
 
 }
 
+typedef Dates_DateTypeDef = DateTime;
+typedef Dates_DateArray = List<DateTime>;
+typedef Dates_DateMap = Map<String, DateTime>;
 
 class Dates_DateStruct {
   DateTime dateField;
@@ -129,6 +132,7 @@ final _smokeDatesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Dates_release_handle'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -10,21 +10,24 @@ import 'package:library/src/generic_types__conversion.dart';
 abstract class DatesSteady implements Finalizable {
 
 
-  DateTime dateMethod(DateTime input);
+  DatesSteady_MonotonicDate dateMethod(DatesSteady_MonotonicDate input);
 
-  DateTime? nullableDateMethod(DateTime? input);
+  DatesSteady_MonotonicDate? nullableDateMethod(DatesSteady_MonotonicDate? input);
 
-  List<DateTime> dateListMethod(List<DateTime> input);
+  DatesSteady_DateList dateListMethod(DatesSteady_DateList input);
 }
 
+typedef DatesSteady_MonotonicDate = DateTime;
+typedef DatesSteady_DateList = List<DatesSteady_MonotonicDate>;
+typedef DatesSteady_DateMap = Map<DatesSteady_MonotonicDate, String>;
 
 class DatesSteady_DateStruct {
-  DateTime dateField;
+  DatesSteady_MonotonicDate dateField;
 
-  DateTime? nullableDateField;
+  DatesSteady_MonotonicDate? nullableDateField;
 
   DatesSteady_DateStruct._(this.dateField, this.nullableDateField);
-  DatesSteady_DateStruct(DateTime dateField)
+  DatesSteady_DateStruct(DatesSteady_MonotonicDate dateField)
     : dateField = dateField, nullableDateField = null;
 }
 
@@ -130,12 +133,13 @@ final _smokeDatessteadyReleaseHandle = __lib.catchArgumentError(() => __lib.nati
 
 
 
+
 class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
 
   DatesSteady$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  DateTime dateMethod(DateTime input) {
+  DatesSteady_MonotonicDate dateMethod(DatesSteady_MonotonicDate input) {
     final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DatesSteady_dateMethod__Date'));
     final _inputHandle = dateToFfi(input);
     final _handle = this.handle;
@@ -151,7 +155,7 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
   }
 
   @override
-  DateTime? nullableDateMethod(DateTime? input) {
+  DatesSteady_MonotonicDate? nullableDateMethod(DatesSteady_MonotonicDate? input) {
     final _nullableDateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_nullableDateMethod__Date_'));
     final _inputHandle = dateToFfiNullable(input);
     final _handle = this.handle;
@@ -167,7 +171,7 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
   }
 
   @override
-  List<DateTime> dateListMethod(List<DateTime> input) {
+  DatesSteady_DateList dateListMethod(DatesSteady_DateList input) {
     final _dateListMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_dateListMethod__ListOf_Date_std_2chrono_2steady_1clock_2time_1point'));
     final _inputHandle = foobarListofDateStd2chrono2steady1clock2time1pointToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -18,6 +18,12 @@ abstract class DefaultValues implements Finalizable {
   static dynamic $prototype = DefaultValues$Impl(Pointer<Void>.fromAddress(0));
 }
 
+typedef DefaultValues_LongTypedef = int;
+typedef DefaultValues_BooleanTypedef = bool;
+typedef DefaultValues_StringTypedef = String;
+typedef DefaultValues_FloatArray = List<double>;
+typedef DefaultValues_IdToStringMap = Map<int, String>;
+typedef DefaultValues_StringSet = Set<String>;
 
 class DefaultValues_StructWithDefaults {
   int intField;
@@ -422,13 +428,13 @@ void smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandleNullable(Pointer
 class DefaultValues_StructWithEmptyDefaults {
   List<int> intsField;
 
-  List<double> floatsField;
+  DefaultValues_FloatArray floatsField;
 
-  Map<int, String> mapField;
+  DefaultValues_IdToStringMap mapField;
 
   DefaultValues_StructWithDefaults structField;
 
-  Set<String> setTypeField;
+  DefaultValues_StringSet setTypeField;
 
   DefaultValues_StructWithEmptyDefaults._(this.intsField, this.floatsField, this.mapField, this.structField, this.setTypeField);
   DefaultValues_StructWithEmptyDefaults()
@@ -546,11 +552,11 @@ void smokeDefaultvaluesStructwithemptydefaultsReleaseFfiHandleNullable(Pointer<V
 // End of DefaultValues_StructWithEmptyDefaults "private" section.
 
 class DefaultValues_StructWithTypedefDefaults {
-  int longField;
+  DefaultValues_LongTypedef longField;
 
-  bool boolField;
+  DefaultValues_BooleanTypedef boolField;
 
-  String stringField;
+  DefaultValues_StringTypedef stringField;
 
   DefaultValues_StructWithTypedefDefaults._(this.longField, this.boolField, this.stringField);
   DefaultValues_StructWithTypedefDefaults()
@@ -668,6 +674,7 @@ final _smokeDefaultvaluesReleaseHandle = __lib.catchArgumentError(() => __lib.na
 
 /// @nodoc
 @visibleForTesting
+
 class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
 
   DefaultValues$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -1,16 +1,28 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
+import 'package:library/src/smoke/default_values.dart';
+
+
 class StructWithInitializerDefaults {
   List<int> intsField;
-  List<double> floatsField;
-  Set<String> setTypeField;
-  Map<int, String> mapField;
+
+  DefaultValues_FloatArray floatsField;
+
+  DefaultValues_StringSet setTypeField;
+
+  DefaultValues_IdToStringMap mapField;
+
   StructWithInitializerDefaults._(this.intsField, this.floatsField, this.setTypeField, this.mapField);
   StructWithInitializerDefaults()
     : intsField = [4, -2, 42], floatsField = [3.14, double.negativeInfinity], setTypeField = {"foo", "bar"}, mapField = {1: "foo", 42: "bar"};
 }
+
+
 // StructWithInitializerDefaults "private" section, not exported.
+
 final _smokeStructwithinitializerdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -35,6 +47,9 @@ final _smokeStructwithinitializerdefaultsGetFieldmapField = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_field_mapField'));
+
+
+
 Pointer<Void> smokeStructwithinitializerdefaultsToFfi(StructWithInitializerDefaults value) {
   final _intsFieldHandle = foobarListofIntToFfi(value.intsField);
   final _floatsFieldHandle = foobarListofFloatToFfi(value.floatsField);
@@ -47,6 +62,7 @@ Pointer<Void> smokeStructwithinitializerdefaultsToFfi(StructWithInitializerDefau
   foobarMapofUintToStringReleaseFfiHandle(_mapFieldHandle);
   return _result;
 }
+
 StructWithInitializerDefaults smokeStructwithinitializerdefaultsFromFfi(Pointer<Void> handle) {
   final _intsFieldHandle = _smokeStructwithinitializerdefaultsGetFieldintsField(handle);
   final _floatsFieldHandle = _smokeStructwithinitializerdefaultsGetFieldfloatsField(handle);
@@ -54,9 +70,9 @@ StructWithInitializerDefaults smokeStructwithinitializerdefaultsFromFfi(Pointer<
   final _mapFieldHandle = _smokeStructwithinitializerdefaultsGetFieldmapField(handle);
   try {
     return StructWithInitializerDefaults._(
-      foobarListofIntFromFfi(_intsFieldHandle),
-      foobarListofFloatFromFfi(_floatsFieldHandle),
-      foobarSetofStringFromFfi(_setTypeFieldHandle),
+      foobarListofIntFromFfi(_intsFieldHandle), 
+      foobarListofFloatFromFfi(_floatsFieldHandle), 
+      foobarSetofStringFromFfi(_setTypeFieldHandle), 
       foobarMapofUintToStringFromFfi(_mapFieldHandle)
     );
   } finally {
@@ -66,8 +82,11 @@ StructWithInitializerDefaults smokeStructwithinitializerdefaultsFromFfi(Pointer<
     foobarMapofUintToStringReleaseFfiHandle(_mapFieldHandle);
   }
 }
+
 void smokeStructwithinitializerdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeStructwithinitializerdefaultsReleaseHandle(handle);
+
 // Nullable StructWithInitializerDefaults
+
 final _smokeStructwithinitializerdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -80,6 +99,7 @@ final _smokeStructwithinitializerdefaultsGetValueNullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_value_nullable'));
+
 Pointer<Void> smokeStructwithinitializerdefaultsToFfiNullable(StructWithInitializerDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeStructwithinitializerdefaultsToFfi(value);
@@ -87,6 +107,7 @@ Pointer<Void> smokeStructwithinitializerdefaultsToFfiNullable(StructWithInitiali
   smokeStructwithinitializerdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 StructWithInitializerDefaults? smokeStructwithinitializerdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeStructwithinitializerdefaultsGetValueNullable(handle);
@@ -94,6 +115,10 @@ StructWithInitializerDefaults? smokeStructwithinitializerdefaultsFromFfiNullable
   smokeStructwithinitializerdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeStructwithinitializerdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructwithinitializerdefaultsReleaseHandleNullable(handle);
+
 // End of StructWithInitializerDefaults "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
@@ -14,6 +14,7 @@ abstract class EnumDefaults implements Finalizable {
 
 }
 
+typedef EnumDefaults_EnumAlias = Enum3;
 
 class EnumDefaults_SimpleEnum {
   Enum1 enumField;
@@ -191,7 +192,7 @@ void smokeEnumdefaultsNullableenumReleaseFfiHandleNullable(Pointer<Void> handle)
 // End of EnumDefaults_NullableEnum "private" section.
 
 class EnumDefaults_AliasEnum {
-  Enum3 enumField;
+  EnumDefaults_EnumAlias enumField;
 
   EnumDefaults_AliasEnum._(this.enumField);
   EnumDefaults_AliasEnum()
@@ -368,6 +369,7 @@ final _smokeEnumdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_release_handle'));
+
 
 
 class EnumDefaults$Impl extends __lib.NativeBase implements EnumDefaults {

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
@@ -17,6 +17,7 @@ abstract class EnumDefaultsExternal implements Finalizable {
 
 }
 
+typedef EnumDefaultsExternal_EnumAlias = alien_enum3.ExternalEnum3;
 
 class EnumDefaultsExternal_SimpleEnum {
   alien_enum1.ExternalEnum1 enumField;
@@ -194,7 +195,7 @@ void smokeEnumdefaultsexternalNullableenumReleaseFfiHandleNullable(Pointer<Void>
 // End of EnumDefaultsExternal_NullableEnum "private" section.
 
 class EnumDefaultsExternal_AliasEnum {
-  alien_enum3.alien_enum3.ExternalEnum3 enumField;
+  EnumDefaultsExternal_EnumAlias enumField;
 
   EnumDefaultsExternal_AliasEnum._(this.enumField);
   EnumDefaultsExternal_AliasEnum()

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -5,6 +5,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 
 abstract class DurationMilliseconds implements Finalizable {
 
@@ -17,6 +18,11 @@ abstract class DurationMilliseconds implements Finalizable {
 
 }
 
+typedef DurationMilliseconds_DurationTypeAlias = Duration;
+typedef DurationMilliseconds_DurationList = List<Duration>;
+typedef DurationMilliseconds_DurationSet = Set<Duration>;
+typedef DurationMilliseconds_DurationMap = Map<String, Duration>;
+typedef DurationMilliseconds_DurationKeyMap = Map<Duration, String>;
 
 class DurationMilliseconds_DurationStruct {
   Duration durationField;
@@ -112,6 +118,7 @@ final _smokeDurationmillisecondsReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DurationMilliseconds_release_handle'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -5,6 +5,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 
 abstract class DurationSeconds implements Finalizable {
 
@@ -17,6 +18,11 @@ abstract class DurationSeconds implements Finalizable {
 
 }
 
+typedef DurationSeconds_DurationTypeAlias = Duration;
+typedef DurationSeconds_DurationList = List<Duration>;
+typedef DurationSeconds_DurationSet = Set<Duration>;
+typedef DurationSeconds_DurationMap = Map<String, Duration>;
+typedef DurationSeconds_DurationKeyMap = Map<Duration, String>;
 
 class DurationSeconds_DurationStruct {
   Duration durationField;
@@ -112,6 +118,7 @@ final _smokeDurationsecondsReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DurationSeconds_release_handle'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -5,6 +5,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 
 abstract class Enums implements Finalizable {
@@ -23,6 +24,7 @@ abstract class Enums implements Finalizable {
   static dynamic $prototype = Enums$Impl(Pointer<Void>.fromAddress(0));
 }
 
+typedef Enums_ExampleMap = Map<Enums_SimpleEnum, int>;
 enum Enums_SimpleEnum {
     first,
     second
@@ -261,6 +263,7 @@ final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
 
 /// @nodoc
 @visibleForTesting
+
 class Enums$Impl extends __lib.NativeBase implements Enums {
 
   Enums$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -10,6 +10,7 @@ import 'package:library/src/generic_types__conversion.dart';
 class Equatable {
 }
 
+typedef Equatable_ErrorCodeToMessageMap = Map<int, String>;
 enum Equatable_SomeEnum {
     foo,
     bar
@@ -92,7 +93,7 @@ class Equatable_EquatableStruct {
 
   List<String> arrayField;
 
-  Map<int, String> mapField;
+  Equatable_ErrorCodeToMessageMap mapField;
 
   Equatable_EquatableStruct(this.boolField, this.intField, this.longField, this.floatField, this.doubleField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   @override
@@ -301,7 +302,7 @@ class Equatable_EquatableNullableStruct {
 
   List<String>? arrayField;
 
-  Map<int, String>? mapField;
+  Equatable_ErrorCodeToMessageMap? mapField;
 
   Equatable_EquatableNullableStruct._(this.boolField, this.intField, this.uintField, this.floatField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   Equatable_EquatableNullableStruct()

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -16,7 +16,7 @@ abstract class Class implements Interface, Finalizable {
   factory Class() => $prototype.constructor();
 
 
-  Types_Struct fun(List<Types_Struct> double);
+  Types_Struct fun(Types_ULong double);
   Types_Enum get property;
   set property(Types_Enum value);
 
@@ -68,6 +68,7 @@ final _funpackageClassFunListofPackageTypesStructReturnHasError = __lib.catchArg
 
 /// @nodoc
 @visibleForTesting
+
 class Class$Impl extends __lib.NativeBase implements Class {
 
   Class$Impl(Pointer<Void> handle) : super(handle);
@@ -80,6 +81,7 @@ class Class$Impl extends __lib.NativeBase implements Class {
     __lib.cacheInstance(_result_handle, _result);
 
     _packageClassRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+
     return _result;
   }
 
@@ -90,7 +92,7 @@ class Class$Impl extends __lib.NativeBase implements Class {
   }
 
   @override
-  Types_Struct fun(List<Types_Struct> double) {
+  Types_Struct fun(Types_ULong double) {
     final _funFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_package_Types_Struct'));
     final _doubleHandle = foobarListofPackageTypesStructToFfi(double);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -2,6 +2,7 @@
 
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/generic_types__conversion.dart';
 
 
 class Types {
@@ -9,6 +10,7 @@ class Types {
 
 }
 
+typedef Types_ULong = List<Types_Struct>;
 enum Types_Enum {
     naN
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -15,11 +15,11 @@ abstract class GenericTypesWithBasicTypes implements Finalizable {
 
   Set<int> methodWithSet(Set<int> input);
 
-  List<String> methodWithListTypeAlias(List<String> input);
+  GenericTypesWithBasicTypes_BasicList methodWithListTypeAlias(GenericTypesWithBasicTypes_BasicList input);
 
-  Map<String, String> methodWithMapTypeAlias(Map<String, String> input);
+  GenericTypesWithBasicTypes_BasicMap methodWithMapTypeAlias(GenericTypesWithBasicTypes_BasicMap input);
 
-  Set<String> methodWithSetTypeAlias(Set<String> input);
+  GenericTypesWithBasicTypes_BasicSet methodWithSetTypeAlias(GenericTypesWithBasicTypes_BasicSet input);
   List<double> get listProperty;
   set listProperty(List<double> value);
 
@@ -31,6 +31,9 @@ abstract class GenericTypesWithBasicTypes implements Finalizable {
 
 }
 
+typedef GenericTypesWithBasicTypes_BasicList = List<String>;
+typedef GenericTypesWithBasicTypes_BasicMap = Map<String, String>;
+typedef GenericTypesWithBasicTypes_BasicSet = Set<String>;
 
 class GenericTypesWithBasicTypes_StructWithGenerics {
   List<int> numbersList;
@@ -156,6 +159,7 @@ final _smokeGenerictypeswithbasictypesReleaseHandle = __lib.catchArgumentError((
 
 
 
+
 class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements GenericTypesWithBasicTypes {
 
   GenericTypesWithBasicTypes$Impl(Pointer<Void> handle) : super(handle);
@@ -209,7 +213,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
   }
 
   @override
-  List<String> methodWithListTypeAlias(List<String> input) {
+  GenericTypesWithBasicTypes_BasicList methodWithListTypeAlias(GenericTypesWithBasicTypes_BasicList input) {
     final _methodWithListTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_String'));
     final _inputHandle = foobarListofStringToFfi(input);
     final _handle = this.handle;
@@ -225,7 +229,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
   }
 
   @override
-  Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
+  GenericTypesWithBasicTypes_BasicMap methodWithMapTypeAlias(GenericTypesWithBasicTypes_BasicMap input) {
     final _methodWithMapTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_String_to_String'));
     final _inputHandle = foobarMapofStringToStringToFfi(input);
     final _handle = this.handle;
@@ -241,7 +245,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
   }
 
   @override
-  Set<String> methodWithSetTypeAlias(Set<String> input) {
+  GenericTypesWithBasicTypes_BasicSet methodWithSetTypeAlias(GenericTypesWithBasicTypes_BasicSet input) {
     final _methodWithSetTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_String'));
     final _inputHandle = foobarSetofStringToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -16,7 +16,7 @@ abstract class CalculatorListener implements Finalizable {
     void Function(double) onCalculationResultConstLambda,
     void Function(CalculatorListener_ResultStruct) onCalculationResultStructLambda,
     void Function(List<double>) onCalculationResultArrayLambda,
-    void Function(Map<String, double>) onCalculationResultMapLambda,
+    void Function(CalculatorListener_NamedCalculationResults) onCalculationResultMapLambda,
     void Function(CalculationResult) onCalculationResultInstanceLambda,
 
   ) => CalculatorListener$Lambdas(
@@ -38,11 +38,12 @@ abstract class CalculatorListener implements Finalizable {
 
   void onCalculationResultArray(List<double> calculationResult);
 
-  void onCalculationResultMap(Map<String, double> calculationResults);
+  void onCalculationResultMap(CalculatorListener_NamedCalculationResults calculationResults);
 
   void onCalculationResultInstance(CalculationResult calculationResult);
 }
 
+typedef CalculatorListener_NamedCalculationResults = Map<String, double>;
 
 class CalculatorListener_ResultStruct {
   double result;
@@ -158,7 +159,7 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   void Function(double) onCalculationResultConstLambda;
   void Function(CalculatorListener_ResultStruct) onCalculationResultStructLambda;
   void Function(List<double>) onCalculationResultArrayLambda;
-  void Function(Map<String, double>) onCalculationResultMapLambda;
+  void Function(CalculatorListener_NamedCalculationResults) onCalculationResultMapLambda;
   void Function(CalculationResult) onCalculationResultInstanceLambda;
 
   CalculatorListener$Lambdas(
@@ -184,7 +185,7 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   void onCalculationResultArray(List<double> calculationResult) =>
     onCalculationResultArrayLambda(calculationResult);
   @override
-  void onCalculationResultMap(Map<String, double> calculationResults) =>
+  void onCalculationResultMap(CalculatorListener_NamedCalculationResults calculationResults) =>
     onCalculationResultMapLambda(calculationResults);
   @override
   void onCalculationResultInstance(CalculationResult calculationResult) =>
@@ -236,7 +237,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
   }
 
   @override
-  void onCalculationResultMap(Map<String, double> calculationResults) {
+  void onCalculationResultMap(CalculatorListener_NamedCalculationResults calculationResults) {
     final _onCalculationResultMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_String_to_Double'));
     final _calculationResultsHandle = foobarMapofStringToDoubleToFfi(calculationResults);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -23,8 +23,8 @@ abstract class ListenerWithProperties implements Finalizable {
     void Function(ListenerWithProperties_ResultEnum) enumeratedMessageSetLambda,
     List<String> Function() arrayedMessageGetLambda,
     void Function(List<String>) arrayedMessageSetLambda,
-    Map<String, double> Function() mappedMessageGetLambda,
-    void Function(Map<String, double>) mappedMessageSetLambda,
+    ListenerWithProperties_StringToDouble Function() mappedMessageGetLambda,
+    void Function(ListenerWithProperties_StringToDouble) mappedMessageSetLambda,
     Uint8List Function() bufferedMessageGetLambda,
     void Function(Uint8List) bufferedMessageSetLambda
   ) => ListenerWithProperties$Lambdas(
@@ -59,14 +59,15 @@ abstract class ListenerWithProperties implements Finalizable {
   List<String> get arrayedMessage;
   set arrayedMessage(List<String> value);
 
-  Map<String, double> get mappedMessage;
-  set mappedMessage(Map<String, double> value);
+  ListenerWithProperties_StringToDouble get mappedMessage;
+  set mappedMessage(ListenerWithProperties_StringToDouble value);
 
   Uint8List get bufferedMessage;
   set bufferedMessage(Uint8List value);
 
 }
 
+typedef ListenerWithProperties_StringToDouble = Map<String, double>;
 enum ListenerWithProperties_ResultEnum {
     none,
     result
@@ -244,8 +245,8 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   void Function(ListenerWithProperties_ResultEnum) enumeratedMessageSetLambda;
   List<String> Function() arrayedMessageGetLambda;
   void Function(List<String>) arrayedMessageSetLambda;
-  Map<String, double> Function() mappedMessageGetLambda;
-  void Function(Map<String, double>) mappedMessageSetLambda;
+  ListenerWithProperties_StringToDouble Function() mappedMessageGetLambda;
+  void Function(ListenerWithProperties_StringToDouble) mappedMessageSetLambda;
   Uint8List Function() bufferedMessageGetLambda;
   void Function(Uint8List) bufferedMessageSetLambda;
 
@@ -287,9 +288,9 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   @override
   set arrayedMessage(List<String> value) => arrayedMessageSetLambda(value);
   @override
-  Map<String, double> get mappedMessage => mappedMessageGetLambda();
+  ListenerWithProperties_StringToDouble get mappedMessage => mappedMessageGetLambda();
   @override
-  set mappedMessage(Map<String, double> value) => mappedMessageSetLambda(value);
+  set mappedMessage(ListenerWithProperties_StringToDouble value) => mappedMessageSetLambda(value);
   @override
   Uint8List get bufferedMessage => bufferedMessageGetLambda();
   @override
@@ -420,7 +421,7 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
   }
 
 
-  Map<String, double> get mappedMessage {
+  ListenerWithProperties_StringToDouble get mappedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -434,7 +435,7 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
   }
 
 
-  set mappedMessage(Map<String, double> value) {
+  set mappedMessage(ListenerWithProperties_StringToDouble value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_String_to_Double'));
     final _valueHandle = foobarMapofStringToDoubleToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -17,7 +17,7 @@ abstract class ListenersWithReturnValues implements Finalizable {
     ListenersWithReturnValues_ResultStruct Function() fetchDataStructLambda,
     ListenersWithReturnValues_ResultEnum Function() fetchDataEnumLambda,
     List<double> Function() fetchDataArrayLambda,
-    Map<String, double> Function() fetchDataMapLambda,
+    ListenersWithReturnValues_StringToDouble Function() fetchDataMapLambda,
     CalculationResult Function() fetchDataInstanceLambda,
 
   ) => ListenersWithReturnValues$Lambdas(
@@ -42,11 +42,12 @@ abstract class ListenersWithReturnValues implements Finalizable {
 
   List<double> fetchDataArray();
 
-  Map<String, double> fetchDataMap();
+  ListenersWithReturnValues_StringToDouble fetchDataMap();
 
   CalculationResult fetchDataInstance();
 }
 
+typedef ListenersWithReturnValues_StringToDouble = Map<String, double>;
 enum ListenersWithReturnValues_ResultEnum {
     none,
     result
@@ -226,7 +227,7 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   ListenersWithReturnValues_ResultStruct Function() fetchDataStructLambda;
   ListenersWithReturnValues_ResultEnum Function() fetchDataEnumLambda;
   List<double> Function() fetchDataArrayLambda;
-  Map<String, double> Function() fetchDataMapLambda;
+  ListenersWithReturnValues_StringToDouble Function() fetchDataMapLambda;
   CalculationResult Function() fetchDataInstanceLambda;
 
   ListenersWithReturnValues$Lambdas(
@@ -256,7 +257,7 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   List<double> fetchDataArray() =>
     fetchDataArrayLambda();
   @override
-  Map<String, double> fetchDataMap() =>
+  ListenersWithReturnValues_StringToDouble fetchDataMap() =>
     fetchDataMapLambda();
   @override
   CalculationResult fetchDataInstance() =>
@@ -338,7 +339,7 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
   }
 
   @override
-  Map<String, double> fetchDataMap() {
+  ListenersWithReturnValues_StringToDouble fetchDataMap() {
     final _fetchDataMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap'));
     final _handle = this.handle;
     final __resultHandle = _fetchDataMapFfi(_handle, __lib.LibraryContext.isolateId);
@@ -409,7 +410,7 @@ void _smokeListenerswithreturnvaluesfetchDataArrayStatic(ListenersWithReturnValu
   }
 }
 void _smokeListenerswithreturnvaluesfetchDataMapStatic(ListenersWithReturnValues _obj, Pointer<Pointer<Void>> _result) {
-  Map<String, double>? _resultObject;
+  ListenersWithReturnValues_StringToDouble? _resultObject;
   try {
     _resultObject = _obj.fetchDataMap();
     _result.value = foobarMapofStringToDoubleToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -6,6 +6,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 
 abstract class Locales implements Finalizable {
 
@@ -16,6 +17,11 @@ abstract class Locales implements Finalizable {
 
 }
 
+typedef Locales_LocaleTypeDef = Locale;
+typedef Locales_LocaleArray = List<Locale>;
+typedef Locales_LocaleMap = Map<String, Locale>;
+typedef Locales_LocaleSet = Set<Locale>;
+typedef Locales_LocaleKeyMap = Map<Locale, String>;
 
 class Locales_LocaleStruct {
   Locale localeField;
@@ -111,6 +117,7 @@ final _smokeLocalesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Locales_release_handle'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -20,17 +20,19 @@ abstract class MethodOverloads implements Finalizable {
 
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4);
 
-  bool isBooleanStringArray(List<String> input);
+  bool isBooleanStringArray(MethodOverloads_StringArray input);
 
-  bool isBooleanIntArray(List<int> input);
+  bool isBooleanIntArray(MethodOverloads_IntArray input);
 
   bool isBooleanConst();
 
   bool isFloatString(String input);
 
-  bool isFloatList(List<int> input);
+  bool isFloatList(MethodOverloads_IntArray input);
 }
 
+typedef MethodOverloads_StringArray = List<String>;
+typedef MethodOverloads_IntArray = List<int>;
 
 class MethodOverloads_Point {
   double x;
@@ -149,6 +151,7 @@ final _smokeMethodoverloadsReleaseHandle = __lib.catchArgumentError(() => __lib.
 
 
 
+
 class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
 
   MethodOverloads$Impl(Pointer<Void> handle) : super(handle);
@@ -240,7 +243,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
   }
 
   @override
-  bool isBooleanStringArray(List<String> input) {
+  bool isBooleanStringArray(MethodOverloads_StringArray input) {
     final _isBooleanStringArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_String'));
     final _inputHandle = foobarListofStringToFfi(input);
     final _handle = this.handle;
@@ -256,7 +259,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
   }
 
   @override
-  bool isBooleanIntArray(List<int> input) {
+  bool isBooleanIntArray(MethodOverloads_IntArray input) {
     final _isBooleanIntArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_Byte'));
     final _inputHandle = foobarListofByteToFfi(input);
     final _handle = this.handle;
@@ -302,7 +305,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
   }
 
   @override
-  bool isFloatList(List<int> input) {
+  bool isFloatList(MethodOverloads_IntArray input) {
     final _isFloatListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_Byte'));
     final _inputHandle = foobarListofByteToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -38,6 +38,7 @@ class OuterStruct {
   static dynamic $prototype = OuterStruct$Impl();
 }
 
+typedef OuterStruct_TypeAlias = OuterStruct_InnerEnum;
 enum OuterStruct_InnerEnum {
     foo,
     bar
@@ -101,7 +102,7 @@ void smokeOuterstructInnerenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
 
 // End of OuterStruct_InnerEnum "private" section.
 class OuterStruct_InstantiationException implements Exception {
-  final OuterStruct_InnerEnum error;
+  final OuterStruct_TypeAlias error;
   OuterStruct_InstantiationException(this.error);
 }
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -8,11 +8,12 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
+import 'package:library/src/smoke/free_type_def.dart';
 
 abstract class UseFreeTypes implements Finalizable {
 
 
-  DateTime doStuff(FreePoint point, FreeEnum mode);
+  FreeTypeDef doStuff(FreePoint point, FreeEnum mode);
 }
 
 
@@ -50,12 +51,13 @@ final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnHasError = __lib.ca
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
 
 
+
 class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
 
   UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  DateTime doStuff(FreePoint point, FreeEnum mode) {
+  FreeTypeDef doStuff(FreePoint point, FreeEnum mode) {
     final _doStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
     final _pointHandle = smokeFreepointToFfi(point);
     final _modeHandle = smokeFreeenumToFfi(mode);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -23,11 +23,11 @@ abstract class Nullable implements Finalizable {
 
   Nullable_SomeEnum? methodWithSomeEnum(Nullable_SomeEnum? input);
 
-  List<String>? methodWithSomeArray(List<String>? input);
+  Nullable_SomeArray? methodWithSomeArray(Nullable_SomeArray? input);
 
   List<String>? methodWithInlineArray(List<String>? input);
 
-  Map<int, String>? methodWithSomeMap(Map<int, String>? input);
+  Nullable_SomeMap? methodWithSomeMap(Nullable_SomeMap? input);
 
   SomeInterface? methodWithInstance(SomeInterface? input);
   String? get stringProperty;
@@ -48,20 +48,22 @@ abstract class Nullable implements Finalizable {
   Nullable_SomeEnum? get enumProperty;
   set enumProperty(Nullable_SomeEnum? value);
 
-  List<String>? get arrayProperty;
-  set arrayProperty(List<String>? value);
+  Nullable_SomeArray? get arrayProperty;
+  set arrayProperty(Nullable_SomeArray? value);
 
   List<String>? get inlineArrayProperty;
   set inlineArrayProperty(List<String>? value);
 
-  Map<int, String>? get mapProperty;
-  set mapProperty(Map<int, String>? value);
+  Nullable_SomeMap? get mapProperty;
+  set mapProperty(Nullable_SomeMap? value);
 
   SomeInterface? get instanceProperty;
   set instanceProperty(SomeInterface? value);
 
 }
 
+typedef Nullable_SomeArray = List<String>;
+typedef Nullable_SomeMap = Map<int, String>;
 enum Nullable_SomeEnum {
     on,
     off
@@ -216,11 +218,11 @@ class Nullable_NullableStruct {
 
   Nullable_SomeEnum? enumField;
 
-  List<String>? arrayField;
+  Nullable_SomeArray? arrayField;
 
   List<String>? inlineArrayField;
 
-  Map<int, String>? mapField;
+  Nullable_SomeMap? mapField;
 
   SomeInterface? instanceField;
 
@@ -560,6 +562,7 @@ final _smokeNullableReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
 
 
 
+
 class Nullable$Impl extends __lib.NativeBase implements Nullable {
 
   Nullable$Impl(Pointer<Void> handle) : super(handle);
@@ -661,7 +664,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
   }
 
   @override
-  List<String>? methodWithSomeArray(List<String>? input) {
+  Nullable_SomeArray? methodWithSomeArray(Nullable_SomeArray? input) {
     final _methodWithSomeArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_String_'));
     final _inputHandle = foobarListofStringToFfiNullable(input);
     final _handle = this.handle;
@@ -693,7 +696,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
   }
 
   @override
-  Map<int, String>? methodWithSomeMap(Map<int, String>? input) {
+  Nullable_SomeMap? methodWithSomeMap(Nullable_SomeMap? input) {
     final _methodWithSomeMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_Long_to_String_'));
     final _inputHandle = foobarMapofLongToStringToFfiNullable(input);
     final _handle = this.handle;
@@ -875,7 +878,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
 
 
   @override
-  List<String>? get arrayProperty {
+  Nullable_SomeArray? get arrayProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -889,7 +892,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
   }
 
   @override
-  set arrayProperty(List<String>? value) {
+  set arrayProperty(Nullable_SomeArray? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_String_'));
     final _valueHandle = foobarListofStringToFfiNullable(value);
     final _handle = this.handle;
@@ -925,7 +928,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
 
 
   @override
-  Map<int, String>? get mapProperty {
+  Nullable_SomeMap? get mapProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -939,7 +942,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
   }
 
   @override
-  set mapProperty(Map<int, String>? value) {
+  set mapProperty(Nullable_SomeMap? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_Long_to_String_'));
     final _valueHandle = foobarMapofLongToStringToFfiNullable(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 class weeTypes {
 }
 
+typedef weeTypes_BasicTypedef = double;
 enum weeTypes_werrEnum {
     WEE_ITEM
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -26,6 +26,7 @@ abstract class Structs implements Finalizable {
   static dynamic $prototype = Structs$Impl(Pointer<Void>.fromAddress(0));
 }
 
+typedef Structs_ArrayOfImmutable = List<Structs_AllTypesStruct>;
 enum Structs_FooBar {
     foo,
     bar
@@ -684,7 +685,7 @@ void smokeStructsDoublenestingimmutablestructReleaseFfiHandleNullable(Pointer<Vo
 // End of Structs_DoubleNestingImmutableStruct "private" section.
 
 class Structs_StructWithArrayOfImmutable {
-  List<Structs_AllTypesStruct> arrayField;
+  Structs_ArrayOfImmutable arrayField;
 
   Structs_StructWithArrayOfImmutable(this.arrayField);
 }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/smoke.dart
@@ -1,0 +1,6 @@
+
+
+export 'src/smoke/global_list_type_def.dart' show GlobalListTypeDef;
+export 'src/smoke/global_map_type_def.dart' show GlobalMapTypeDef;
+export 'src/smoke/type_collection.dart' show TypeCollection, TypeCollection_Point, TypeCollection_PointTypeDef, TypeCollection_StorageId, TypeCollection_StructHavingAliasFieldDefinedBelow;
+export 'src/smoke/type_defs.dart' show TypeDefs, TypeDefs$Impl, TypeDefs_ComplexTypeDef, TypeDefs_NestedIntTypeDef, TypeDefs_NestedStructTypeDef, TypeDefs_PrimitiveTypeDef, TypeDefs_StructArray, TypeDefs_StructHavingAliasFieldDefinedBelow, TypeDefs_TestStruct, TypeDefs_TestStructTypeDef;

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/global_list_type_def.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/global_list_type_def.dart
@@ -1,0 +1,8 @@
+
+
+import 'package:library/src/generic_types__conversion.dart';
+
+/// This is some standalone list typedef.
+typedef GlobalListTypeDef = List<double>;
+
+

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/global_map_type_def.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/global_map_type_def.dart
@@ -1,0 +1,8 @@
+
+
+import 'package:library/src/generic_types__conversion.dart';
+
+/// This is some standalone map typedef.
+typedef GlobalMapTypeDef = Map<int, String>;
+
+

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -12,19 +12,19 @@ import 'package:meta/meta.dart';
 abstract class TypeDefs implements Finalizable {
 
 
-  static double methodWithPrimitiveTypeDef(double input) => $prototype.methodWithPrimitiveTypeDef(input);
+  static TypeDefs_PrimitiveTypeDef methodWithPrimitiveTypeDef(TypeDefs_PrimitiveTypeDef input) => $prototype.methodWithPrimitiveTypeDef(input);
 
-  static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) => $prototype.methodWithComplexTypeDef(input);
+  static TypeDefs_ComplexTypeDef methodWithComplexTypeDef(TypeDefs_ComplexTypeDef input) => $prototype.methodWithComplexTypeDef(input);
 
-  static double returnNestedIntTypeDef(double input) => $prototype.returnNestedIntTypeDef(input);
+  static TypeDefs_NestedIntTypeDef returnNestedIntTypeDef(TypeDefs_NestedIntTypeDef input) => $prototype.returnNestedIntTypeDef(input);
 
-  static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) => $prototype.returnTestStructTypeDef(input);
+  static TypeDefs_TestStructTypeDef returnTestStructTypeDef(TypeDefs_TestStructTypeDef input) => $prototype.returnTestStructTypeDef(input);
 
-  static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) => $prototype.returnNestedStructTypeDef(input);
+  static TypeDefs_NestedStructTypeDef returnNestedStructTypeDef(TypeDefs_NestedStructTypeDef input) => $prototype.returnNestedStructTypeDef(input);
 
-  static TypeCollection_Point returnTypeDefPointFromTypeCollection(TypeCollection_Point input) => $prototype.returnTypeDefPointFromTypeCollection(input);
-  List<double> get primitiveTypeProperty;
-  set primitiveTypeProperty(List<double> value);
+  static TypeCollection_PointTypeDef returnTypeDefPointFromTypeCollection(TypeCollection_PointTypeDef input) => $prototype.returnTypeDefPointFromTypeCollection(input);
+  List<TypeDefs_PrimitiveTypeDef> get primitiveTypeProperty;
+  set primitiveTypeProperty(List<TypeDefs_PrimitiveTypeDef> value);
 
 
   /// @nodoc
@@ -32,9 +32,15 @@ abstract class TypeDefs implements Finalizable {
   static dynamic $prototype = TypeDefs$Impl(Pointer<Void>.fromAddress(0));
 }
 
+typedef TypeDefs_NestedIntTypeDef = TypeDefs_PrimitiveTypeDef;
+typedef TypeDefs_PrimitiveTypeDef = double;
+typedef TypeDefs_StructArray = List<TypeDefs_TestStruct>;
+typedef TypeDefs_ComplexTypeDef = TypeDefs_StructArray;
+typedef TypeDefs_TestStructTypeDef = TypeDefs_TestStruct;
+typedef TypeDefs_NestedStructTypeDef = TypeDefs_TestStructTypeDef;
 
 class TypeDefs_StructHavingAliasFieldDefinedBelow {
-  double field;
+  TypeDefs_PrimitiveTypeDef field;
 
   TypeDefs_StructHavingAliasFieldDefinedBelow(this.field);
 }
@@ -217,11 +223,12 @@ final _smokeTypedefsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
 
 /// @nodoc
 @visibleForTesting
+
 class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 
   TypeDefs$Impl(Pointer<Void> handle) : super(handle);
 
-  double methodWithPrimitiveTypeDef(double input) {
+  TypeDefs_PrimitiveTypeDef methodWithPrimitiveTypeDef(TypeDefs_PrimitiveTypeDef input) {
     final _methodWithPrimitiveTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _methodWithPrimitiveTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -235,7 +242,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 
   }
 
-  List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
+  TypeDefs_ComplexTypeDef methodWithComplexTypeDef(TypeDefs_ComplexTypeDef input) {
     final _methodWithComplexTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_smoke_TypeDefs_TestStruct'));
     final _inputHandle = foobarListofSmokeTypedefsTeststructToFfi(input);
     final __resultHandle = _methodWithComplexTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -249,7 +256,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 
   }
 
-  double returnNestedIntTypeDef(double input) {
+  TypeDefs_NestedIntTypeDef returnNestedIntTypeDef(TypeDefs_NestedIntTypeDef input) {
     final _returnNestedIntTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _returnNestedIntTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -263,7 +270,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 
   }
 
-  TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
+  TypeDefs_TestStructTypeDef returnTestStructTypeDef(TypeDefs_TestStructTypeDef input) {
     final _returnTestStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct'));
     final _inputHandle = smokeTypedefsTeststructToFfi(input);
     final __resultHandle = _returnTestStructTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -277,7 +284,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 
   }
 
-  TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
+  TypeDefs_NestedStructTypeDef returnNestedStructTypeDef(TypeDefs_NestedStructTypeDef input) {
     final _returnNestedStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct'));
     final _inputHandle = smokeTypedefsTeststructToFfi(input);
     final __resultHandle = _returnNestedStructTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -291,7 +298,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 
   }
 
-  TypeCollection_Point returnTypeDefPointFromTypeCollection(TypeCollection_Point input) {
+  TypeCollection_PointTypeDef returnTypeDefPointFromTypeCollection(TypeCollection_PointTypeDef input) {
     final _returnTypeDefPointFromTypeCollectionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
     final _inputHandle = smokeTypecollectionPointToFfi(input);
     final __resultHandle = _returnTypeDefPointFromTypeCollectionFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -306,7 +313,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
   }
 
   @override
-  List<double> get primitiveTypeProperty {
+  List<TypeDefs_PrimitiveTypeDef> get primitiveTypeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -320,7 +327,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
   }
 
   @override
-  set primitiveTypeProperty(List<double> value) {
+  set primitiveTypeProperty(List<TypeDefs_PrimitiveTypeDef> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_Double'));
     final _valueHandle = foobarListofDoubleToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_class.dart
@@ -5,11 +5,18 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 
 abstract class PublicClass implements Finalizable {
 
 }
 
+/// @nodoc
+typedef _PublicClass_InternalArray = List<PublicClass_InternalStruct>;
+/// @nodoc
+typedef _PublicClass_InternalStructTypeDef = PublicClass_InternalStruct;
+/// @nodoc
+typedef _PublicClass_StringToInternalStructMap = Map<String, PublicClass_InternalStruct>;
 /// @nodoc
 enum PublicClass_InternalEnum {
     foo,
@@ -344,6 +351,7 @@ final _smokePublicclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_release_handle'));
+
 
 
 class PublicClass$Impl extends __lib.NativeBase implements PublicClass {


### PR DESCRIPTION
Added dedicated DartTypeAlias template, as type aliases (typedefs) are now
supported in Dart language (since Dart version 2.13). Updated other Dart
tempates and resolvers to treat type aliases as a normal type, instead of
skipping it through to the target type.

Added/updated related smoke and functional tests.
Unrelated smoke tests are updated in a separate commit.

Resolves: https://github.com/heremaps/gluecodium/issues/907

This MR is a rebase of an old draft created by Daniel + more tests.
Original author: Daniel Kamkha <daniel.kamkha@here.com>