### PR TITLE
Dart: use bullet points to document parameters in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 ### Features:
-  * Dart: added support for type aliases (typedefs).
+ * Dart: added support for type aliases (typedefs).
+### Bug-fixes:
+ * Dart: removed redundant white-spaces from rendered comments for constructors of structures. Adjusted the rendered comments to list parameters using bullet points to improve readability.
 
 ## 13.15.1
 Release date 2025-06-05

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -21,7 +21,7 @@
 {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
 ///{{/unless}}{{/resolveName}}{{!!
 }}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}
-/// [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
+/// - [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
 ///{{/unless}}{{/resolveName}}{{/set}}{{/parameters}}{{!!
 }}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}
 /// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}

--- a/gluecodium/src/main/resources/templates/dart/DartLambdaDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambdaDocs.mustache
@@ -25,7 +25,7 @@
 {{/ifPredicate}}{{!!
 }}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}
 ///
-/// [{{self.parameterName}}] {{prefix this "/// " skipFirstLine=true}}
+/// - [{{self.parameterName}}] {{prefix this "/// " skipFirstLine=true}}
 {{/unless}}{{/resolveName}}{{/set}}{{/parameters}}
 {{#if attributes.deprecated}}
 @Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -112,7 +112,7 @@ Explicit `field constructor` definitions
 }}{{+constructorComment}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// "}}
 {{#fields}}{{!!
-}}  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+}}  /// - [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}{{!!
 }}{{/unless}}{{/resolveName}}{{/constructorComment}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -78,15 +78,15 @@ Explicit `field constructor` definitions
 }}{{#set struct=this container=this}}{{#fieldConstructors}}
 {{#unless comment.isEmpty}}{{#resolveName comment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// "}}
-{{#fields}}
-  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
-  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{#fields}}{{!!
+}}  /// - [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}{{/unless}}{{/resolveName}}{{/unless}}{{!!
 }}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// "}}
-{{#fields}}
-  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
-  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{#fields}}{{!!
+}}  /// - [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}{{/unless}}{{/resolveName}}{{/if}}{{!!
 }}{{#if this.comment.isExcluded}}
   /// @nodoc

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -111,10 +111,10 @@ Explicit `field constructor` definitions
 
 }}{{+constructorComment}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// "}}
-{{#fields}}
-  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
-  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
-{{/fields}}
-{{/unless}}{{/resolveName}}{{/constructorComment}}{{!!
+{{#fields}}{{!!
+}}  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}{{!!
+}}{{/unless}}{{/resolveName}}{{/constructorComment}}{{!!
 
 }}{{+thisDotFields}}{{#fields}}this.{{resolveName "visibility"}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/thisDotFields}}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -312,9 +312,9 @@ void smokeCommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
 // End of Comments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
 ///
-/// [p0] Very useful input parameter
+/// - [p0] Very useful input parameter
 ///
-/// [p1] Slightly less useful input parameter
+/// - [p1] Slightly less useful input parameter
 ///
 /// Returns Usefulness of the input
 typedef Comments_SomeLambda = double Function(String, int);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -191,9 +191,9 @@ class Comments_SomeStruct {
   String? nullableField;
 
   /// This is how easy it is to construct.
-  /// [someField] How useful this struct is
+  /// - [someField] How useful this struct is
   /// remains to be seen
-  /// [nullableField] Can be `null`
+  /// - [nullableField] Can be `null`
   Comments_SomeStruct._(this.someField, this.nullableField);
   Comments_SomeStruct(Comments_Usefulness someField)
     : someField = someField, nullableField = null;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -191,12 +191,9 @@ class Comments_SomeStruct {
   String? nullableField;
 
   /// This is how easy it is to construct.
-
   /// [someField] How useful this struct is
   /// remains to be seen
-
   /// [nullableField] Can be `null`
-
   Comments_SomeStruct._(this.someField, this.nullableField);
   Comments_SomeStruct(Comments_Usefulness someField)
     : someField = someField, nullableField = null;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -15,7 +15,7 @@ abstract class Comments implements Finalizable {
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// [inputParameter] Very useful input parameter
+  /// - [inputParameter] Very useful input parameter
   ///
   /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
@@ -24,7 +24,7 @@ abstract class Comments implements Finalizable {
   Comments_Usefulness someMethodWithAllComments(String inputParameter);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   Comments_Usefulness someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
@@ -37,7 +37,7 @@ abstract class Comments implements Finalizable {
   Comments_Usefulness someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   void someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
@@ -57,7 +57,7 @@ abstract class Comments implements Finalizable {
   ///
   void someMethodWithoutReturnTypeOrInputParameters();
 
-  /// [documented] nicely documented
+  /// - [documented] nicely documented
   ///
   String oneParameterCommentOnly(String undocumented, String documented);
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -44,14 +44,14 @@ abstract class CommentsInterface implements Finalizable {
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
   CommentsInterface_Usefulness someMethodWithAllComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   CommentsInterface_Usefulness someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
@@ -64,7 +64,7 @@ abstract class CommentsInterface implements Finalizable {
   CommentsInterface_Usefulness someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   void someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
@@ -488,7 +488,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
 
   /// Sets some very useful property.
   ///
-  /// [value] Some very useful property.
+  /// - [value] Some very useful property.
   ///
   set isSomeProperty(CommentsInterface_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -70,7 +70,7 @@ class CommentsLinks_RandomStruct {
   Comments_SomeStruct randomField;
 
   /// constructor comments [Comments_SomeStruct]
-  /// [randomField] Some random field [Comments_SomeStruct]
+  /// - [randomField] Some random field [Comments_SomeStruct]
   CommentsLinks_RandomStruct(this.randomField);
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -48,7 +48,7 @@ abstract class CommentsLinks implements Finalizable {
   /// Not working for Swift:
   /// * named comment: [][Comments.veryUseful]
   ///
-  /// [inputParameter] Sometimes takes [Comments_SomeEnum.useful]
+  /// - [inputParameter] Sometimes takes [Comments_SomeEnum.useful]
   ///
   /// Returns [Comments_SomeEnum]. Sometimes returns [Comments_SomeEnum.useful]
   ///

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -70,9 +70,7 @@ class CommentsLinks_RandomStruct {
   Comments_SomeStruct randomField;
 
   /// constructor comments [Comments_SomeStruct]
-
   /// [randomField] Some random field [Comments_SomeStruct]
-
   CommentsLinks_RandomStruct(this.randomField);
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -33,7 +33,7 @@ abstract class DeprecationComments implements Finalizable {
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   /// Returns [DeprecationComments_Usefulness]. Usefulness of the input
   ///
@@ -304,7 +304,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
 
   /// Sets some very useful property.
   ///
-  /// [value] Some very useful property.
+  /// - [value] Some very useful property.
   ///
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
 
@@ -334,7 +334,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   }
 
 
-  /// [value] Describes the property but not accessors.
+  /// - [value] Describes the property but not accessors.
   ///
   @Deprecated("Will be removed in v3.2.1.")
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -25,7 +25,7 @@ abstract class DeprecationCommentsOnly implements Finalizable {
   static final DeprecationCommentsOnly_Usefulness veryUseful = true;
 
 
-  /// [input] Very useful input parameter
+  /// - [input] Very useful input parameter
   ///
   /// Returns [DeprecationCommentsOnly_Usefulness]. Usefulness of the input
   ///

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -16,7 +16,7 @@ abstract class ExcludedComments implements Finalizable {
 
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// [inputParameter] Very useful input parameter
+  /// - [inputParameter] Very useful input parameter
   ///
   /// Returns [ExcludedComments_Usefulness]. Usefulness of the input
   ///

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -119,10 +119,8 @@ class ExcludedComments_SomeStruct {
   ExcludedComments_Usefulness someField;
 
   /// This is how easy it is to construct.
-
   /// [someField] How useful this struct is
   /// remains to be seen
-
   ExcludedComments_SomeStruct(this.someField);
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -119,7 +119,7 @@ class ExcludedComments_SomeStruct {
   ExcludedComments_Usefulness someField;
 
   /// This is how easy it is to construct.
-  /// [someField] How useful this struct is
+  /// - [someField] How useful this struct is
   /// remains to be seen
   ExcludedComments_SomeStruct(this.someField);
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -200,9 +200,9 @@ void smokeExcludedcommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handl
 /// This is some very useful lambda that does it.
 /// @nodoc
 ///
-/// [p0] Very useful input parameter
+/// - [p0] Very useful input parameter
 ///
-/// [p1] Slightly less useful input parameter
+/// - [p1] Slightly less useful input parameter
 ///
 /// Returns Usefulness of the input
 typedef ExcludedComments_SomeLambda = double Function(String, int);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/lambda_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/lambda_comments.dart
@@ -12,7 +12,7 @@ abstract class LambdaComments implements Finalizable {
 
 /// The first line of the doc.
 ///
-/// [p0] The first input parameter
+/// - [p0] The first input parameter
 typedef LambdaComments_WithNoNamedParameters = String Function(String);
 
 // LambdaComments_WithNoNamedParameters "private" section, not exported.
@@ -256,7 +256,7 @@ void smokeLambdacommentsWithnodocsforparametersReleaseFfiHandleNullable(Pointer<
 // End of LambdaComments_WithNoDocsForParameters "private" section.
 /// The first line of the doc.
 ///
-/// [inputParameter] The first input parameter. The second sentence of the first input parameter.
+/// - [inputParameter] The first input parameter. The second sentence of the first input parameter.
 ///
 /// Returns The string.
 typedef LambdaComments_WithNamedParameters = String Function(String inputParameter);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -27,11 +27,11 @@ abstract class MultiLineComments implements Finalizable {
   /// It has very important parameters.
   /// It has side effects.
   ///
-  /// [input] Very useful input parameter.
+  /// - [input] Very useful input parameter.
   /// You must not confuse it with the second parameter.
   /// But they are similar.
   ///
-  /// [ratio] Not as useful as the first parameter.
+  /// - [ratio] Not as useful as the first parameter.
   /// But still useful.
   /// use a positive value for more happiness.
   ///
@@ -58,6 +58,7 @@ final _smokeMultilinecommentsReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultiLineComments_release_handle'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -16,7 +16,7 @@ abstract class PlatformComments implements Finalizable {
   void doMagic();
   /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
   ///
-  /// [input] Very useful parameter that \[\esc@pe{s}\]
+  /// - [input] Very useful parameter that \[\esc@pe{s}\]
   ///
   /// Returns [bool]. Uselessness [PlatformComments_SomeEnum] of the input
   ///
@@ -212,6 +212,7 @@ final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsSt
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -11,7 +11,7 @@ abstract class UnicodeComments implements Finalizable {
 
   /// Süßölgefäß
   ///
-  /// [input] שלום
+  /// - [input] שלום
   ///
   /// Returns [Comments_Usefulness]. товарищ
   ///

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
@@ -1,18 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// Foo Bar this is a comment
+
 class DartDeprecatedPosDefaults {
   int intField;
+
   String stringField;
+
   /// buzz fizz
-  /// [intField]
-  /// [stringField]
+  /// [intField] 
+  /// [stringField] 
   @Deprecated("Sorry, this is deprecated.")
   DartDeprecatedPosDefaults(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;
 }
+
+
 // DartDeprecatedPosDefaults "private" section, not exported.
+
 final _smokeDartdeprecatedposdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
@@ -29,27 +38,36 @@ final _smokeDartdeprecatedposdefaultsGetFieldstringField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartDeprecatedPosDefaults_get_field_stringField'));
+
+
+
 Pointer<Void> smokeDartdeprecatedposdefaultsToFfi(DartDeprecatedPosDefaults value) {
   final _intFieldHandle = (value.intField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeDartdeprecatedposdefaultsCreateHandle(_intFieldHandle, _stringFieldHandle);
+  
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 DartDeprecatedPosDefaults smokeDartdeprecatedposdefaultsFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeDartdeprecatedposdefaultsGetFieldintField(handle);
   final _stringFieldHandle = _smokeDartdeprecatedposdefaultsGetFieldstringField(handle);
   try {
     return DartDeprecatedPosDefaults(
-      stringFromFfi(_stringFieldHandle),
+      stringFromFfi(_stringFieldHandle), 
       (_intFieldHandle)
     );
   } finally {
+    
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeDartdeprecatedposdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDartdeprecatedposdefaultsReleaseHandle(handle);
+
 // Nullable DartDeprecatedPosDefaults
+
 final _smokeDartdeprecatedposdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -62,6 +80,7 @@ final _smokeDartdeprecatedposdefaultsGetValueNullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartDeprecatedPosDefaults_get_value_nullable'));
+
 Pointer<Void> smokeDartdeprecatedposdefaultsToFfiNullable(DartDeprecatedPosDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDartdeprecatedposdefaultsToFfi(value);
@@ -69,6 +88,7 @@ Pointer<Void> smokeDartdeprecatedposdefaultsToFfiNullable(DartDeprecatedPosDefau
   smokeDartdeprecatedposdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 DartDeprecatedPosDefaults? smokeDartdeprecatedposdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDartdeprecatedposdefaultsGetValueNullable(handle);
@@ -76,6 +96,10 @@ DartDeprecatedPosDefaults? smokeDartdeprecatedposdefaultsFromFfiNullable(Pointer
   smokeDartdeprecatedposdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDartdeprecatedposdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDartdeprecatedposdefaultsReleaseHandleNullable(handle);
+
 // End of DartDeprecatedPosDefaults "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
@@ -12,8 +12,8 @@ class DartDeprecatedPosDefaults {
   String stringField;
 
   /// buzz fizz
-  /// [intField] 
-  /// [stringField] 
+  /// - [intField] 
+  /// - [stringField] 
   @Deprecated("Sorry, this is deprecated.")
   DartDeprecatedPosDefaults(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
@@ -1,23 +1,35 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
+
+
 /// Foo Bar this is a comment
+
 class DartDeprecatedPosDefaultsCustom {
   int intField;
+
   String stringField;
+
   /// buzz fizz
-  /// [intField]
-  /// [stringField]
+  /// [intField] 
+  /// [stringField] 
   @Deprecated("Sorry, this is deprecated.")
   DartDeprecatedPosDefaultsCustom(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;
+
   factory DartDeprecatedPosDefaultsCustom() => $prototype.custom();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = DartDeprecatedPosDefaultsCustom$Impl();
 }
+
+
 // DartDeprecatedPosDefaultsCustom "private" section, not exported.
+
 final _smokeDartdeprecatedposdefaultscustomCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
@@ -34,6 +46,9 @@ final _smokeDartdeprecatedposdefaultscustomGetFieldstringField = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartDeprecatedPosDefaultsCustom_get_field_stringField'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class DartDeprecatedPosDefaultsCustom$Impl {
@@ -44,30 +59,40 @@ class DartDeprecatedPosDefaultsCustom$Impl {
       return smokeDartdeprecatedposdefaultscustomFromFfi(__resultHandle);
     } finally {
       smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 Pointer<Void> smokeDartdeprecatedposdefaultscustomToFfi(DartDeprecatedPosDefaultsCustom value) {
   final _intFieldHandle = (value.intField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeDartdeprecatedposdefaultscustomCreateHandle(_intFieldHandle, _stringFieldHandle);
+  
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 DartDeprecatedPosDefaultsCustom smokeDartdeprecatedposdefaultscustomFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeDartdeprecatedposdefaultscustomGetFieldintField(handle);
   final _stringFieldHandle = _smokeDartdeprecatedposdefaultscustomGetFieldstringField(handle);
   try {
     return DartDeprecatedPosDefaultsCustom(
-      stringFromFfi(_stringFieldHandle),
+      stringFromFfi(_stringFieldHandle), 
       (_intFieldHandle)
     );
   } finally {
+    
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(Pointer<Void> handle) => _smokeDartdeprecatedposdefaultscustomReleaseHandle(handle);
+
 // Nullable DartDeprecatedPosDefaultsCustom
+
 final _smokeDartdeprecatedposdefaultscustomCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -80,6 +105,7 @@ final _smokeDartdeprecatedposdefaultscustomGetValueNullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartDeprecatedPosDefaultsCustom_get_value_nullable'));
+
 Pointer<Void> smokeDartdeprecatedposdefaultscustomToFfiNullable(DartDeprecatedPosDefaultsCustom? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDartdeprecatedposdefaultscustomToFfi(value);
@@ -87,6 +113,7 @@ Pointer<Void> smokeDartdeprecatedposdefaultscustomToFfiNullable(DartDeprecatedPo
   smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(_handle);
   return result;
 }
+
 DartDeprecatedPosDefaultsCustom? smokeDartdeprecatedposdefaultscustomFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDartdeprecatedposdefaultscustomGetValueNullable(handle);
@@ -94,6 +121,10 @@ DartDeprecatedPosDefaultsCustom? smokeDartdeprecatedposdefaultscustomFromFfiNull
   smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDartdeprecatedposdefaultscustomReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDartdeprecatedposdefaultscustomReleaseHandleNullable(handle);
+
 // End of DartDeprecatedPosDefaultsCustom "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
@@ -14,8 +14,8 @@ class DartDeprecatedPosDefaultsCustom {
   String stringField;
 
   /// buzz fizz
-  /// [intField] 
-  /// [stringField] 
+  /// - [intField] 
+  /// - [stringField] 
   @Deprecated("Sorry, this is deprecated.")
   DartDeprecatedPosDefaultsCustom(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_both_comments.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_both_comments.dart
@@ -1,14 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// SomeStruct
+
 class FieldConstructorWithBothComments {
   String stringField;
+
   /// This comment takes precedence
-  /// [stringField]
+  /// - [stringField] 
   FieldConstructorWithBothComments(this.stringField);
 }
+
+
 // FieldConstructorWithBothComments "private" section, not exported.
+
 final _smokeFieldconstructorwithbothcommentsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -21,12 +29,16 @@ final _smokeFieldconstructorwithbothcommentsGetFieldstringField = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithBothComments_get_field_stringField'));
+
+
+
 Pointer<Void> smokeFieldconstructorwithbothcommentsToFfi(FieldConstructorWithBothComments value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeFieldconstructorwithbothcommentsCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 FieldConstructorWithBothComments smokeFieldconstructorwithbothcommentsFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeFieldconstructorwithbothcommentsGetFieldstringField(handle);
   try {
@@ -37,8 +49,11 @@ FieldConstructorWithBothComments smokeFieldconstructorwithbothcommentsFromFfi(Po
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeFieldconstructorwithbothcommentsReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithbothcommentsReleaseHandle(handle);
+
 // Nullable FieldConstructorWithBothComments
+
 final _smokeFieldconstructorwithbothcommentsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -51,6 +66,7 @@ final _smokeFieldconstructorwithbothcommentsGetValueNullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithBothComments_get_value_nullable'));
+
 Pointer<Void> smokeFieldconstructorwithbothcommentsToFfiNullable(FieldConstructorWithBothComments? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFieldconstructorwithbothcommentsToFfi(value);
@@ -58,6 +74,7 @@ Pointer<Void> smokeFieldconstructorwithbothcommentsToFfiNullable(FieldConstructo
   smokeFieldconstructorwithbothcommentsReleaseFfiHandle(_handle);
   return result;
 }
+
 FieldConstructorWithBothComments? smokeFieldconstructorwithbothcommentsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFieldconstructorwithbothcommentsGetValueNullable(handle);
@@ -65,6 +82,10 @@ FieldConstructorWithBothComments? smokeFieldconstructorwithbothcommentsFromFfiNu
   smokeFieldconstructorwithbothcommentsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFieldconstructorwithbothcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFieldconstructorwithbothcommentsReleaseHandleNullable(handle);
+
 // End of FieldConstructorWithBothComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_comment.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_comment.dart
@@ -1,15 +1,23 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// SomeStruct
+
 class FieldConstructorWithComment {
   /// Some field
   String stringField;
+
   /// Some field constructor
-  /// [stringField] Some field
+  /// - [stringField] Some field
   FieldConstructorWithComment(this.stringField);
 }
+
+
 // FieldConstructorWithComment "private" section, not exported.
+
 final _smokeFieldconstructorwithcommentCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -22,12 +30,16 @@ final _smokeFieldconstructorwithcommentGetFieldstringField = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithComment_get_field_stringField'));
+
+
+
 Pointer<Void> smokeFieldconstructorwithcommentToFfi(FieldConstructorWithComment value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeFieldconstructorwithcommentCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 FieldConstructorWithComment smokeFieldconstructorwithcommentFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeFieldconstructorwithcommentGetFieldstringField(handle);
   try {
@@ -38,8 +50,11 @@ FieldConstructorWithComment smokeFieldconstructorwithcommentFromFfi(Pointer<Void
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeFieldconstructorwithcommentReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithcommentReleaseHandle(handle);
+
 // Nullable FieldConstructorWithComment
+
 final _smokeFieldconstructorwithcommentCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -52,6 +67,7 @@ final _smokeFieldconstructorwithcommentGetValueNullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithComment_get_value_nullable'));
+
 Pointer<Void> smokeFieldconstructorwithcommentToFfiNullable(FieldConstructorWithComment? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFieldconstructorwithcommentToFfi(value);
@@ -59,6 +75,7 @@ Pointer<Void> smokeFieldconstructorwithcommentToFfiNullable(FieldConstructorWith
   smokeFieldconstructorwithcommentReleaseFfiHandle(_handle);
   return result;
 }
+
 FieldConstructorWithComment? smokeFieldconstructorwithcommentFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFieldconstructorwithcommentGetValueNullable(handle);
@@ -66,6 +83,10 @@ FieldConstructorWithComment? smokeFieldconstructorwithcommentFromFfiNullable(Poi
   smokeFieldconstructorwithcommentReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFieldconstructorwithcommentReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFieldconstructorwithcommentReleaseHandleNullable(handle);
+
 // End of FieldConstructorWithComment "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_and_comment.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_and_comment.dart
@@ -1,14 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
+
 class FieldConstructorWithDeprecationAndComment {
   String stringField;
+
   /// Some field constructor
-  /// [stringField]
+  /// - [stringField] 
   @Deprecated("Shouldn't really use it")
   FieldConstructorWithDeprecationAndComment(this.stringField);
 }
+
+
 // FieldConstructorWithDeprecationAndComment "private" section, not exported.
+
 final _smokeFieldconstructorwithdeprecationandcommentCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -21,12 +29,16 @@ final _smokeFieldconstructorwithdeprecationandcommentGetFieldstringField = __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithDeprecationAndComment_get_field_stringField'));
+
+
+
 Pointer<Void> smokeFieldconstructorwithdeprecationandcommentToFfi(FieldConstructorWithDeprecationAndComment value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeFieldconstructorwithdeprecationandcommentCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 FieldConstructorWithDeprecationAndComment smokeFieldconstructorwithdeprecationandcommentFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeFieldconstructorwithdeprecationandcommentGetFieldstringField(handle);
   try {
@@ -37,8 +49,11 @@ FieldConstructorWithDeprecationAndComment smokeFieldconstructorwithdeprecationan
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithdeprecationandcommentReleaseHandle(handle);
+
 // Nullable FieldConstructorWithDeprecationAndComment
+
 final _smokeFieldconstructorwithdeprecationandcommentCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -51,6 +66,7 @@ final _smokeFieldconstructorwithdeprecationandcommentGetValueNullable = __lib.ca
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithDeprecationAndComment_get_value_nullable'));
+
 Pointer<Void> smokeFieldconstructorwithdeprecationandcommentToFfiNullable(FieldConstructorWithDeprecationAndComment? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFieldconstructorwithdeprecationandcommentToFfi(value);
@@ -58,6 +74,7 @@ Pointer<Void> smokeFieldconstructorwithdeprecationandcommentToFfiNullable(FieldC
   smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandle(_handle);
   return result;
 }
+
 FieldConstructorWithDeprecationAndComment? smokeFieldconstructorwithdeprecationandcommentFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFieldconstructorwithdeprecationandcommentGetValueNullable(handle);
@@ -65,6 +82,10 @@ FieldConstructorWithDeprecationAndComment? smokeFieldconstructorwithdeprecationa
   smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFieldconstructorwithdeprecationandcommentReleaseHandleNullable(handle);
+
 // End of FieldConstructorWithDeprecationAndComment "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded.dart
@@ -1,15 +1,23 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
+
 class FieldConstructorWithExcluded {
   /// Some field
   String stringField;
+
   /// Some field constructor
-  /// [stringField] Some field
+  /// - [stringField] Some field
   /// @nodoc
   FieldConstructorWithExcluded(this.stringField);
 }
+
+
 // FieldConstructorWithExcluded "private" section, not exported.
+
 final _smokeFieldconstructorwithexcludedCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -22,12 +30,16 @@ final _smokeFieldconstructorwithexcludedGetFieldstringField = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithExcluded_get_field_stringField'));
+
+
+
 Pointer<Void> smokeFieldconstructorwithexcludedToFfi(FieldConstructorWithExcluded value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeFieldconstructorwithexcludedCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 FieldConstructorWithExcluded smokeFieldconstructorwithexcludedFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeFieldconstructorwithexcludedGetFieldstringField(handle);
   try {
@@ -38,8 +50,11 @@ FieldConstructorWithExcluded smokeFieldconstructorwithexcludedFromFfi(Pointer<Vo
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeFieldconstructorwithexcludedReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithexcludedReleaseHandle(handle);
+
 // Nullable FieldConstructorWithExcluded
+
 final _smokeFieldconstructorwithexcludedCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -52,6 +67,7 @@ final _smokeFieldconstructorwithexcludedGetValueNullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithExcluded_get_value_nullable'));
+
 Pointer<Void> smokeFieldconstructorwithexcludedToFfiNullable(FieldConstructorWithExcluded? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFieldconstructorwithexcludedToFfi(value);
@@ -59,6 +75,7 @@ Pointer<Void> smokeFieldconstructorwithexcludedToFfiNullable(FieldConstructorWit
   smokeFieldconstructorwithexcludedReleaseFfiHandle(_handle);
   return result;
 }
+
 FieldConstructorWithExcluded? smokeFieldconstructorwithexcludedFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFieldconstructorwithexcludedGetValueNullable(handle);
@@ -66,6 +83,10 @@ FieldConstructorWithExcluded? smokeFieldconstructorwithexcludedFromFfiNullable(P
   smokeFieldconstructorwithexcludedReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFieldconstructorwithexcludedReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFieldconstructorwithexcludedReleaseHandleNullable(handle);
+
 // End of FieldConstructorWithExcluded "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_parent_comment.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_parent_comment.dart
@@ -1,14 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// SomeStruct
+
 class FieldConstructorWithParentComment {
   String stringField;
+
   /// There are constructors
-  /// [stringField]
+  /// - [stringField] 
   FieldConstructorWithParentComment(this.stringField);
 }
+
+
 // FieldConstructorWithParentComment "private" section, not exported.
+
 final _smokeFieldconstructorwithparentcommentCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -21,12 +29,16 @@ final _smokeFieldconstructorwithparentcommentGetFieldstringField = __lib.catchAr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithParentComment_get_field_stringField'));
+
+
+
 Pointer<Void> smokeFieldconstructorwithparentcommentToFfi(FieldConstructorWithParentComment value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeFieldconstructorwithparentcommentCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 FieldConstructorWithParentComment smokeFieldconstructorwithparentcommentFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeFieldconstructorwithparentcommentGetFieldstringField(handle);
   try {
@@ -37,8 +49,11 @@ FieldConstructorWithParentComment smokeFieldconstructorwithparentcommentFromFfi(
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeFieldconstructorwithparentcommentReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithparentcommentReleaseHandle(handle);
+
 // Nullable FieldConstructorWithParentComment
+
 final _smokeFieldconstructorwithparentcommentCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -51,6 +66,7 @@ final _smokeFieldconstructorwithparentcommentGetValueNullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorWithParentComment_get_value_nullable'));
+
 Pointer<Void> smokeFieldconstructorwithparentcommentToFfiNullable(FieldConstructorWithParentComment? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFieldconstructorwithparentcommentToFfi(value);
@@ -58,6 +74,7 @@ Pointer<Void> smokeFieldconstructorwithparentcommentToFfiNullable(FieldConstruct
   smokeFieldconstructorwithparentcommentReleaseFfiHandle(_handle);
   return result;
 }
+
 FieldConstructorWithParentComment? smokeFieldconstructorwithparentcommentFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFieldconstructorwithparentcommentGetValueNullable(handle);
@@ -65,6 +82,10 @@ FieldConstructorWithParentComment? smokeFieldconstructorwithparentcommentFromFfi
   smokeFieldconstructorwithparentcommentReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFieldconstructorwithparentcommentReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFieldconstructorwithparentcommentReleaseHandleNullable(handle);
+
 // End of FieldConstructorWithParentComment "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_partial_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_partial_defaults.dart
@@ -14,8 +14,8 @@ class FieldConstructorsPartialDefaults {
 
   /// This is some field constructor with two parameters.
   /// It is very important.
-  /// [intField] 
-  /// [stringField] 
+  /// - [intField] 
+  /// - [stringField] 
   FieldConstructorsPartialDefaults.withTrue(this.intField, this.stringField)
       : boolField = true;
   FieldConstructorsPartialDefaults(this.boolField, this.intField, this.stringField);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -15,39 +15,39 @@ import 'package:meta/meta.dart';
 abstract class Thermometer implements Finalizable {
   /// A constructor, which makes the thermometer with readout interval.
   ///
-  /// [interval] readout interval
+  /// - [interval] readout interval
   ///
-  /// [observers] observers of temperature changes
+  /// - [observers] observers of temperature changes
   ///
   factory Thermometer.makeWithDuration(Duration interval, List<TemperatureObserver> observers) => $prototype.makeWithDuration(interval, observers);
   /// A constructor, which makes the thermometer with default readout interval (1 second).
   ///
-  /// [observers] observers of temperature changes
+  /// - [observers] observers of temperature changes
   ///
   factory Thermometer.makeWithoutDuration(List<TemperatureObserver> observers) => $prototype.makeWithoutDuration(observers);
   /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
   ///
-  /// [id] identification of this thermometer
+  /// - [id] identification of this thermometer
   ///
-  /// [observers] observers of temperature changes
+  /// - [observers] observers of temperature changes
   ///
   /// Throws [Thermometer_NotificationException]. if identification number is invalid
   ///
   factory Thermometer.throwingMake(int id, List<TemperatureObserver> observers) => $prototype.throwingMake(id, observers);
   /// A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
   ///
-  /// [label] some identification label
+  /// - [label] some identification label
   ///
-  /// [niceObservers] observers of temperature changes
+  /// - [niceObservers] observers of temperature changes
   ///
   /// Throws [Thermometer_NotificationException]. if notification of observers failed
   ///
   factory Thermometer.nothrowMake(String label, List<TemperatureObserver> niceObservers) => $prototype.nothrowMake(label, niceObservers);
   /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
   ///
-  /// [dummy] some dummy boolean flag
+  /// - [dummy] some dummy boolean flag
   ///
-  /// [observers] observers of temperature changes
+  /// - [observers] observers of temperature changes
   ///
   /// Throws [Thermometer_AnotherNotificationException]. if some problem occurs
   ///
@@ -59,9 +59,9 @@ abstract class Thermometer implements Finalizable {
   static void notifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.notifyObservers(thermometer, someObservers);
   /// Function used to notify observers.
   ///
-  /// [thermometer] subject that has changed state
+  /// - [thermometer] subject that has changed state
   ///
-  /// [someObservers] observers to be notified
+  /// - [someObservers] observers to be notified
   ///
   /// Throws [Thermometer_NotificationException]. if notification of observers failed
   ///


### PR DESCRIPTION
The rendered comments for constructors of structures contained
redundant white-spaces. Because of that DartDoc was not able to
render the description of parameters properly.

Moreover, the generated description of parameters did not contain
bullet points -- they were only separated with new lines.

This change:
 - removes the redundant white-spaces
 - introduces usage of bullet points for comments of params to improve
 readability
