### PR TITLE
CI: use multiple threads to run CMake tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -450,6 +450,7 @@ jobs:
           sudo apt -y install ./dart_${DART_VERSION}-1_amd64.deb
       - name: Build and run functional tests
         run: |
+          export CTEST_PARALLEL_LEVEL=3
           export ANDROID_HOME=${HOME}/android-sdk-linux
           export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:/usr/lib/dart/bin
           ./gradlew publishToMavenLocal


### PR DESCRIPTION
The step, which is responsible for running CMake tests on CI is
extended to use multiple threads. This speeds up the execution.

It is achieved via 'CTEST_PARALLEL_LEVEL' environment variable.