### PR TITLE
Validation: warn when unnamed parameters are documented for lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+ * Validation: `LimeLambdaValidator` class is extended with new functionality to raise warning/error when parameters with default names are explicitly documented.
+
 ## 13.16.0
 Release date 2025-06-13
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
@@ -57,18 +57,26 @@ class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: Gene
     }
 
     private fun validateLambdaDocs(limeLambda: LimeLambda): Boolean {
-        val checkDocsMessage = "please check $LAMBDAS_STRUCTURED_COMMENTS"
+        val checkCommentsDocsMessage = "please check $LAMBDAS_STRUCTURED_COMMENTS"
+        val checkNamedParamsSyntax = "please check $LAMBDAS_NAMED_PARAMS_SYNTAX"
         var result = true
 
         for (parameter in limeLambda.parameters) {
             if (parameter.comment.isEmpty()) {
-                logger.maybeError(limeLambda, "Parameter '${parameter.name}' must be documented; $checkDocsMessage")
+                logger.maybeError(limeLambda, "Parameter '${parameter.name}' must be documented; $checkCommentsDocsMessage")
+                result = false
+            } else if (!parameter.isNamedParameter) {
+                logger.maybeError(
+                    limeLambda,
+                    "Default parameter name '${parameter.name}' is documented. Please set an explicit name for documented parameters; " +
+                        checkNamedParamsSyntax,
+                )
                 result = false
             }
         }
 
         if (!limeLambda.returnType.isVoid && limeLambda.returnType.comment.isEmpty()) {
-            logger.maybeError(limeLambda, "Return must be documented; $checkDocsMessage")
+            logger.maybeError(limeLambda, "Return must be documented; $checkCommentsDocsMessage")
             result = false
         }
 
@@ -77,5 +85,6 @@ class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: Gene
 
     companion object {
         private const val LAMBDAS_STRUCTURED_COMMENTS = "$LIME_MARKDOWN_DOCS#structured-comments-for-lambdas"
+        private const val LAMBDAS_NAMED_PARAMS_SYNTAX = "https://github.com/heremaps/gluecodium/blob/master/docs/lime_idl.md#lambda"
     }
 }


### PR DESCRIPTION
When we do not specify lambda parameter names then 'p0, p1 ... pN' are used.
Such names do not bring any context for the caller to understand their purpose.

Moreover, when such parameters are explicitly documented it is usually a mistake.
Therefore, 'LimeLambdaValidator' class is extended to print warning or error
(depending on 'werror' flag) when parameters without custom names are explicitly
documented for lambdas.