### PR TITLE
cmake-tests: fix test failing on iOS

### DIFF
--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/successful.regex
@@ -1,1 +1,1 @@
-(Failed reading options: File .*/someNonexistentPlaceholders.properties does not exist)|(someNonexistentPlaceholders.properties.*missing and no known rule to make it)
+(Failed reading options: File .*/someNonexistentPlaceholders.properties does not exist)|(someNonexistentPlaceholders.properties.*missing and no known rule to make it)|(file failed to open for reading \(No such file or directory\):.*/someNonexistentPlaceholders.properties)


### PR DESCRIPTION
The test called 'docsplaceholderslist-nonexistent-file-XFAIL' was
failing on iOS due to different error message.

The test case expects CMake to fail (XFAIL) with a specific message,
which is validated via the regular expression.

The regex has been adjusted to ensure that the test passes on iOS.