### PR TITLE
CI: run CMake tests for iOS

### DIFF
--- a/.github/workflows/cmake-tests-macos.yml
+++ b/.github/workflows/cmake-tests-macos.yml
@@ -3,10 +3,10 @@ name: CMake tests on MacOS
 on:
   push:
     paths:
-      - 'cmake/**'
+      - 'gluecodium/**'
   pull_request:
     paths:
-      - 'cmake/**'
+      - 'gluecodium/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cmake-tests-macos.yml
+++ b/.github/workflows/cmake-tests-macos.yml
@@ -1,0 +1,41 @@
+name: CMake tests on MacOS
+
+on:
+  push:
+    paths:
+      - 'cmake/**'
+  pull_request:
+    paths:
+      - 'cmake/**'
+  workflow_dispatch:
+
+jobs:
+  cmake-tests-ios:
+    name: CMake toolchain tests for iOS
+    runs-on: macos-13
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            !*gluecodium*
+            !*lime-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Install ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+        with:
+          version: 1.11.0
+      - name: Build and run functional tests
+        run: |
+          export CTEST_PARALLEL_LEVEL=6
+          ./gradlew publishToMavenLocal
+          cd cmake
+          GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 cmake -P run-cmake-unit-test.cmake

--- a/.github/workflows/cmake-tests-macos.yml
+++ b/.github/workflows/cmake-tests-macos.yml
@@ -3,10 +3,10 @@ name: CMake tests on MacOS
 on:
   push:
     paths:
-      - 'gluecodium/**'
+      - 'cmake/**'
   pull_request:
     paths:
-      - 'gluecodium/**'
+      - 'cmake/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -482,6 +482,7 @@ jobs:
           version: 1.11.0
       - name: Build and run functional tests
         run: |
+          export CTEST_PARALLEL_LEVEL=6
           ./gradlew publishToMavenLocal
           cd cmake
           GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 cmake -P run-cmake-unit-test.cmake

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -456,33 +456,3 @@ jobs:
           ./gradlew publishToMavenLocal
           cd cmake
           GLUECODIUM_BUILD_ENVIRONMENT=android-host cmake -P run-cmake-unit-test.cmake
-
-  cmake-tests-ios:
-    name: CMake toolchain tests for iOS
-    runs-on: macos-13
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 17
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            !*gluecodium*
-            !*lime-*
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - name: Install ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
-        with:
-          version: 1.11.0
-      - name: Build and run functional tests
-        run: |
-          export CTEST_PARALLEL_LEVEL=6
-          ./gradlew publishToMavenLocal
-          cd cmake
-          GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 cmake -P run-cmake-unit-test.cmake

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -402,8 +402,8 @@ jobs:
           cd functional-tests
           ./scripts/build-dart-functional --buildGluecodium --asan
 
-  cmake-tests:
-    name: CMake toolchain tests
+  cmake-tests-android:
+    name: CMake toolchain tests for Android
     runs-on: ubuntu-22.04
 
     steps:
@@ -456,3 +456,32 @@ jobs:
           ./gradlew publishToMavenLocal
           cd cmake
           GLUECODIUM_BUILD_ENVIRONMENT=android-host cmake -P run-cmake-unit-test.cmake
+
+  cmake-tests-ios:
+    name: CMake toolchain tests for iOS
+    runs-on: macos-13
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            !*gluecodium*
+            !*lime-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Install ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+        with:
+          version: 1.11.0
+      - name: Build and run functional tests
+        run: |
+          ./gradlew publishToMavenLocal
+          cd cmake
+          GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 cmake -P run-cmake-unit-test.cmake

--- a/cmake/tests/unit/gluecodium_generate/dart-disable-finalizable-marker/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/dart-disable-finalizable-marker/CMakeLists.txt
@@ -24,6 +24,13 @@ list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
 include(gluecodium/Gluecodium)
 
 include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/check_file_does_not_contain_string_after_build.cmake)
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+get_supported_gluecodium_generators(_gluecodium_generators)
+
+if(NOT dart IN_LIST _gluecodium_generators)
+  return()
+endif()
 
 add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
 

--- a/cmake/tests/unit/gluecodium_generate/werror-not-set/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/werror-not-set/CMakeLists.txt
@@ -26,6 +26,14 @@ list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
 include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/assert.cmake)
 include(gluecodium/Gluecodium)
 
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+get_supported_gluecodium_generators(_gluecodium_generators)
+
+if(NOT dart IN_LIST _gluecodium_generators)
+  return()
+endif()
+
 # Default namespace
 add_library(target.with.warnings SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
 


### PR DESCRIPTION
---------- Motivation ----------
Gluecodium provides a set of CMake scripts, which allows users to integrate
code generation into their build system. Because of the number of parameters
and available configurations such scripts are tested via CMake unit tests.

There are some test cases, which are platform specific. For instance they are
just `android-related` or `ios-related`.

Because of the duration of jobs the pipeline executed on Gluecodium CI runs
CMake toolchain tests only for Android. Therefore, the test cases, which are
iOS-specific may start to fail – there is a chance that we will not catch the problem on CI.

All configured CI jobs finish in less than 10 minutes. CMake tests for iOS take 25-30 minutes
when run with multiple threads.

---------- Solution ----------

The new pipeline called `cmake-tests-macos.yml` is added to CI configuration files.
However, it is not executed for each and every change. It is triggered automatically only
when files from `cmake` directory are modified.

Moreover, the job may be triggered manually via GitHub actions tab, because the pipeline
is configured with `workflow_dispatch` event.