### PR TITLE
Dart/FFI: enter isolate only if callbacks queue is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features:
  * Validation: `LimeLambdaValidator` class is extended with new functionality to raise warning/error when parameters with default names are explicitly documented.
 ### Bug-fixes:
+ * Dart/FFI: the bug related to entering isolate context after the given isolate is closed is solved for execution of Dart callbacks from C++. Since this release the callbacks queue manager received a new function, which checks if callbacks queue for given isolate is open and only in such case enters isolate context before executing a callback.
  * Validation: `LimeValidatorUtils.needsDocumentationComment()` function is extended to avoid raising warnings/errors when a given LimeElement is annotated as internal/skipped for each platform (Java, Kotlin, Swift, Dart).
 
 ## 13.16.0

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -24,6 +24,8 @@
 
 #include "Export.h"
 
+#include "dart_api_dl.h"
+
 #include <chrono>
 #include <functional>
 #include <future>
@@ -124,6 +126,11 @@ public:
      * Ignores the callback if the queue not exist or was already closed.
      **/
     std::future<bool> enqueueCallback(int id, std::function<void()>&& func);
+
+    /**
+     * If the isolate has not finished yet enter its context and execute callback.
+     **/
+     void executeCallbackInIsolateScope(int id, Dart_Isolate isolate, std::function<void()>&& func);
 };
 
 /**

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
@@ -164,6 +164,17 @@ CallbackQueueManager::enqueueCallback(int id, std::function<void()>&& func)
 
     return queue->enqueueIncoming(std::move(func));
 }
+
+void
+CallbackQueueManager::executeCallbackInIsolateScope(int id, Dart_Isolate isolate, std::function<void()>&& func) {
+    auto queue = getQueue(id);
+    if (queue) {
+        Dart_EnterIsolate_DL(isolate);
+        func();
+        Dart_ExitIsolate_DL();
+    }
+}
+
 }
 {{#internalNamespace}}
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -158,9 +158,7 @@ private:
         } else if ({{>ffi/FfiInternal}}::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            {{>ffi/FfiInternal}}::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 {{/if}}

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncClass.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncClass.cpp
@@ -68,9 +68,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -127,9 +125,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -187,9 +183,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -247,9 +241,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -307,9 +299,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -367,9 +357,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -426,9 +414,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncRenamed.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncRenamed.cpp
@@ -65,9 +65,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncWithSkips.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncWithSkips.cpp
@@ -65,9 +65,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationInterface.cpp
@@ -78,9 +78,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -110,9 +110,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_ExternalInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_ExternalInterface.cpp
@@ -82,9 +82,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -89,9 +89,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -77,9 +77,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -141,9 +139,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -201,9 +197,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -267,9 +261,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -331,9 +323,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -69,9 +69,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -127,9 +127,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_InterfaceWithStatic.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_InterfaceWithStatic.cpp
@@ -92,9 +92,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -187,9 +187,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -158,9 +158,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/ffi/ffi_smoke_SpecialNamesInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/ffi/ffi_smoke_SpecialNamesInterface.cpp
@@ -72,9 +72,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -131,9 +129,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -76,9 +76,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -76,9 +76,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -144,9 +142,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterStruct.cpp
@@ -86,9 +86,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };
@@ -145,9 +143,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/ffi/ffi_smoke_NoCacheInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/ffi/ffi_smoke_NoCacheInterface.cpp
@@ -67,9 +67,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_EnableTagsInDart.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_EnableTagsInDart.cpp
@@ -84,9 +84,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
@@ -185,9 +185,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipSetter.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipSetter.cpp
@@ -74,9 +74,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTagsInDart.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTagsInDart.cpp
@@ -80,9 +80,7 @@ private:
         } else if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             callback();
         } else {
-            Dart_EnterIsolate_DL(isolate_handle);
-            callback();
-            Dart_ExitIsolate_DL();
+            gluecodium::ffi::cbqm.executeCallbackInIsolateScope(isolate_id, isolate_handle, std::move(callback));
         }
     }
 };


### PR DESCRIPTION
There are corner cases in which the isolate, for which we
created a callback in the past may be closed. This can happen
when we register platform specific event handler (for instance
'appWillTerminate()' on iOS from Swift). With Flutter 3.29+
such callback is executed after the isolate is finished in some
environments.
    
In such case we should not enter the isolate manually in the
callback proxy. If we do it, then segmentation fault is going
to happen in internals of Dart DL API.
    
This change adjusts the code to check if the callbacks queue
for given isolate is open before entering it. In case when
it is closed, then the call is ignored.