### PR TITLE
Release version 13.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Gluecodium project Release Notes
 
-## Unreleased
+## 13.17.0
+Release date 2025-08-04
 ### Features:
  * Validation: `LimeLambdaValidator` class is extended with new functionality to raise warning/error when parameters with default names are explicitly documented.
 ### Bug-fixes:

--- a/gluecodium/src/main/resources/version.properties
+++ b/gluecodium/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version = 13.16.0
+version = 13.17.0


### PR DESCRIPTION
Features:
 * Validation: 'LimeLambdaValidator' class is extended with new functionality to raise warning/error when parameters with default names are explicitly documented.

Bug-fixes:
 * C++: the compilation error in generated C++ code for equatable structure with set of enumerations is fixed by adjusting the template specialization in 'UnorderedSetHash.h.

 * Validation: 'LimeValidatorUtils.needsDocumentationComment()' function is extended to avoid raising warnings/errors when a given LimeElement is annotated as internal/skipped for each platform (Java, Kotlin, Swift, Dart).
