### PR TITLE
Dart/FFI: allow processing callbacks queue from separate platform task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+ * Dart/FFI: a new public function called `*_library_execute_callbacks_for_isolate_of_current_thread()` is available to execute enqueued callbacks for the current thread. This can be used to implement platform event handlers, which need to wait until certain actions complete. If such handlers block the thread, then no callbacks can be executed -- this may lead to dead locks. The new function can be used together with polling to execute some Dart callbacks while the thread is waiting.
+
 ## 13.17.0
 Release date 2025-08-04
 ### Features:

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleHeader.mustache
@@ -33,6 +33,7 @@ _GLUECODIUM_FFI_EXPORT int32_t {{libraryName}}_library_callbacks_queue_init(bool
 _GLUECODIUM_FFI_EXPORT void {{libraryName}}_library_callbacks_queue_release(int32_t isolate_id);
 _GLUECODIUM_FFI_EXPORT uint8_t {{libraryName}}_library_wait_for_callbacks(int32_t isolate_id);
 _GLUECODIUM_FFI_EXPORT void {{libraryName}}_library_execute_callbacks(int32_t isolate_id);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_library_execute_callbacks_for_isolate_of_current_thread();
 
 #ifdef __cplusplus
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleImpl.mustache
@@ -24,6 +24,8 @@
 
 #include "CallbacksQueue.h"
 
+#include <thread>
+
 namespace {
 // Due to the bug in Flutter (https://github.com/flutter/flutter/issues/58987)
 // hot restart may hangs if isolate is waiting for event in C++.
@@ -62,6 +64,26 @@ void
 {{libraryName}}_library_execute_callbacks(int32_t isolate_id) {
     auto queue = {{>ffi/FfiInternal}}::cbqm.getQueue(isolate_id);
     if (queue) {
+        queue->executeScheduled();
+    }
+}
+
+void
+{{libraryName}}_library_execute_callbacks_for_isolate_of_current_thread() {
+    auto queue = {{>ffi/FfiInternal}}::cbqm.getQueue(std::this_thread::get_id());
+    if (queue == nullptr) {
+        return;
+    }
+
+    // If the function is executed from custom task in a thread it means, that it was scheduled via
+    // some platform specific API or we are called from platform event handler. In such case we are
+    // not in Dart isolate context and we need to enter it.
+    const bool is_invoked_from_custom_task = (Dart_CurrentIsolate_DL() == nullptr);
+    if (is_invoked_from_custom_task) {
+        Dart_EnterIsolate_DL(queue->getIsolateHandle());
+        queue->executeScheduled();
+        Dart_ExitIsolate_DL();
+    } else {
         queue->executeScheduled();
     }
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -32,6 +32,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <thread>
 #include <unordered_map>
 
 {{#internalNamespace}}
@@ -113,6 +114,7 @@ private:
     mutable std::mutex m_mutex;
     int32_t m_next_id = 0;
     std::unordered_map<int, std::shared_ptr<CallbackQueue>> m_queues;
+    std::unordered_map<std::thread::id, int> m_isolate_thread_to_queue_id;
 
 public:
     std::shared_ptr<CallbackQueue> getQueue(int id) const;

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -24,6 +24,8 @@
 
 #include "Export.h"
 
+#include "dart_api_dl.h"
+
 #include <chrono>
 #include <functional>
 #include <future>
@@ -58,12 +60,18 @@ private:
 
     std::condition_variable m_notified;
 
+    Dart_Isolate m_isolate_handle;
+
 public:
     enum class WaitResult {
         Stopped,      // Queue is stopped
         HasIncoming,  // Queue has incomming messages
         TimedOut      // Wait operation is timed out
     };
+
+    CallbackQueue()
+        : m_isolate_handle(Dart_CurrentIsolate_DL())
+    {}
 
     /**
      * Block until there is a callback in incoming or the queue is closed
@@ -89,6 +97,11 @@ public:
      * Close the queue.
      */
     void close();
+
+    /**
+     * Returns the isolate handle associated with the current queue.
+     */
+    Dart_Isolate getIsolateHandle() const;
 };
 
 /**

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -117,7 +117,15 @@ private:
     std::unordered_map<std::thread::id, int> m_isolate_thread_to_queue_id;
 
 public:
+    /*
+     * Returns the callback queue associated with given numeric ID or null if no such queue exists.
+     */
     std::shared_ptr<CallbackQueue> getQueue(int id) const;
+
+    /*
+     * Returns the callback queue associated with given thread ID or null if no such queue exists.
+     */
+    std::shared_ptr<CallbackQueue> getQueue(std::thread::id tid) const;
 
     /**
      * Create CallbackQeue with given id.

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
@@ -170,6 +170,19 @@ CallbackQueueManager::getQueue(int id) const
     return it == m_queues.end() ? std::shared_ptr<CallbackQueue>() : it->second;
 }
 
+std::shared_ptr<CallbackQueue>
+CallbackQueueManager::getQueue(std::thread::id tid) const {
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    auto numeric_id_it = m_isolate_thread_to_queue_id.find(tid);
+    if (numeric_id_it == m_isolate_thread_to_queue_id.end()) {
+        return std::shared_ptr<CallbackQueue>();
+    }
+
+    auto it = m_queues.find(numeric_id_it->second);
+    return it == m_queues.end() ? std::shared_ptr<CallbackQueue>() : it->second;
+}
+
 std::future<bool>
 CallbackQueueManager::enqueueCallback(int id, std::function<void()>&& func)
 {

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
@@ -108,6 +108,12 @@ CallbackQueue::close()
     }
 }
 
+Dart_Isolate
+CallbackQueue::getIsolateHandle() const
+{
+    return m_isolate_handle;
+}
+
 int32_t
 CallbackQueueManager::createQueue()
 {

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
@@ -22,6 +22,8 @@
 
 #include "CallbacksQueue.h"
 
+#include <algorithm>
+
 {{#internalNamespace}}
 namespace {{.}}
 {
@@ -121,6 +123,7 @@ CallbackQueueManager::createQueue()
 
     auto id = m_next_id++;
     m_queues.emplace(id, std::make_shared<CallbackQueue>());
+    m_isolate_thread_to_queue_id.emplace(std::this_thread::get_id(), id);
     return id;
 }
 
@@ -129,11 +132,19 @@ CallbackQueueManager::closeQueue(int id)
 {
     std::unique_lock<std::mutex> lock(m_mutex);
 
+    // Close and remove queue object.
     auto it = m_queues.find(id);
     if (it != m_queues.end())
     {
         it->second.get()->close();
         m_queues.erase(id);
+    }
+
+    // Remove association between isolate thread and the numeric ID.
+    const auto has_same_isolate_id = [id](const auto& entry) { return entry.second == id; };
+    auto thread_it = std::find_if(m_isolate_thread_to_queue_id.begin(), m_isolate_thread_to_queue_id.end(), has_same_isolate_id);
+    if (thread_it != m_isolate_thread_to_queue_id.end()) {
+        m_isolate_thread_to_queue_id.erase(thread_it);
     }
 }
 
@@ -147,6 +158,7 @@ CallbackQueueManager::closeAllQueues()
         queue.second.get()->close();
     }
     m_queues.clear();
+    m_isolate_thread_to_queue_id.clear();
 }
 
 std::shared_ptr<CallbackQueue>


### PR DESCRIPTION
---------- Motivation ----------
Before Flutter 3.29 the following threads were used by the Flutter engine:
 - 'UI Thread' -- it executed Dart code
 - 'Main Platform Thread' -- it executed platform specific callbacks

In Flutter 3.29 these threads were merged into one. The Dart code is executed
now by the 'Main Platform Thread'. The platform specific handlers are also executed
by that thread.

It is important to note that certain platform handlers cannot finish until other actions
are complete. For instance, the 'SurfaceHolder.Callback.surfaceDestroyed()' handler
on Android cannot finish until the separate rendering thread finishes using the resources.

From Android docs:
    "If you have a rendering thread that directly accesses the surface, you must ensure
    that thread is no longer touching the Surface before returning from this function. "

When such handler is executed in the 'Main Platform Thread' the processing of Dart
callbacks queue in Gluecodium does not happen. The whole thread is blocked. This
may lead to dead-lock if the thread, for which the handler is waiting tries to use the
Dart/Flutter callback from C++.

---------- Designed solution ----------
Implemented and exposed a new public function, which allows processing callbacks
queue for a given thread from a separate task (e.g. from platform specific handler).

With the usage of the new function the handlers may implement pooling approach.
In meantime they can process the callbacks queue. This way the risk of deadlock
is mitigated.