### PR TITLE
Release version 13.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Gluecodium project Release Notes
 
-## Unreleased
+## 13.18.0
+Release date 2025-08-07
 ### Features:
  * Dart/FFI: a new public function called `*_library_execute_callbacks_for_isolate_of_current_thread()` is available to execute enqueued callbacks for the current thread. This can be used to implement platform event handlers, which need to wait until certain actions complete. If such handlers block the thread, then no callbacks can be executed -- this may lead to dead locks. The new function can be used together with polling to execute some Dart callbacks while the thread is waiting.
 ### Bug-fixes:

--- a/gluecodium/src/main/resources/version.properties
+++ b/gluecodium/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version = 13.17.0
+version = 13.18.0


### PR DESCRIPTION
Features:
 * Dart/FFI: a new public function called `*_library_execute_callbacks_for_isolate_of_current_thread()` is available to execute enqueued callbacks for the current thread. This can be used to implement platform event handlers, which need to wait until certain actions complete. If such handlers block the thread, then no callbacks can be executed -- this may lead to dead locks. The new function can be used together with polling to execute some Dart callbacks while the thread is waiting.

Bug-fixes:
 * Dart/FFI: the bug related to entering isolate context after the given isolate is closed is solved for execution of Dart callbacks from C++. Since this release the callbacks queue manager received a new function, which checks if callbacks queue for given isolate is open and only in such case enters isolate context before executing a callback.

