### PR TITLE
Kotlin: make interfaces functional by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+ * Kotlin: interfaces are now generated as functional interfaces whenever it is possible.
+
 ## 13.19.0
 Release date 2025-08-11
 ### Features:

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InterfacesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InterfacesTest.kt
@@ -81,6 +81,15 @@ class InterfacesTest {
         assertEquals(INSTANCE_OTHER_STRING, nestedInterface.getInterfaceTwo().getStringValue())
     }
 
+    @org.junit.Test
+    fun functionalInterface() {
+        // If the interface is not functional then compilation fails.
+        val square: SingleMethodInterfaceThatShouldBeFunctional =
+            SingleMethodInterfaceThatShouldBeFunctional { someParam -> someParam*someParam }
+
+        assertEquals(9, square.someFunction(3))
+    }
+
     companion object {
         private val INSTANCE_ONE_STRING: String = "simpleInterfaceOne"
         private val INSTANCE_TWO_STRING: String = "simpleInterfaceTwo"

--- a/functional-tests/functional/input/lime/Interfaces.lime
+++ b/functional-tests/functional/input/lime/Interfaces.lime
@@ -65,3 +65,8 @@ class InterfacesFactory {
 interface InterfaceWithProperty {
     property stringProperty: String
 }
+
+@Skip(Dart, Java, Swift)
+interface SingleMethodInterfaceThatShouldBeFunctional {
+    fun someFunction(someParam: Int): Int
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
@@ -27,6 +27,7 @@ import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeExternalDescriptor
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
@@ -44,6 +45,7 @@ internal object KotlinGeneratorPredicates {
             "hasInternalFreeArgsConstructor" to this::hasInternalFreeArgsConstructor,
             "hasStaticProperties" to this::hasStaticProperties,
             "isExceptionSameForCtorAndHookFun" to this::isExceptionSameForCtorAndHookFun,
+            "isFunctionalInterface" to this::isFunctionalInterface,
             "isInternal" to this::isInternal,
             "propertyGetterRequiresJvmName" to this::propertyGetterRequiresJvmName,
             "propertySetterRequiresJvmName" to this::propertySetterRequiresJvmName,
@@ -117,6 +119,26 @@ internal object KotlinGeneratorPredicates {
             is LimeFunction -> CommonGeneratorPredicates.isExceptionSameForCtorAndHookFun(constructor)
             else -> false
         }
+    }
+
+    private fun isFunctionalInterface(limeInterface: Any): Boolean {
+        if (limeInterface !is LimeInterface) {
+            return false
+        }
+
+        val nonStaticFunctionsCount =
+            limeInterface.functions.filter { !it.isStatic }.size +
+                limeInterface.inheritedFunctions.filter { !it.isStatic }.size
+
+        val nonStaticPropertiesCount =
+            limeInterface.properties.filter { !it.isStatic }.size +
+                limeInterface.inheritedProperties.filter { !it.isStatic }.size
+
+        // In Kotlin, a functional interface:
+        // - can have only one non-static function
+        // - cannot have non-static properties
+        // - can have multiple static functions/properties
+        return nonStaticFunctionsCount == 1 && nonStaticPropertiesCount == 0
     }
 
     private fun needsCompanionObject(element: Any) =

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -19,7 +19,8 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}{{>kotlin/KotlinAttributes}}
-{{resolveName "visibility"}}interface {{resolveName}} {{!!
+{{resolveName "visibility"}}{{!!
+}}{{#ifPredicate "isFunctionalInterface"}}fun {{/ifPredicate}}interface {{resolveName}} {{!!
 }}{{#if this.parents}}: {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
 {{>kotlin/KotlinContainerContents}}
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-interface LambdasInterface {
+fun interface LambdasInterface {
     fun interface TakeScreenshotCallback {
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal interface InternalListener {
+internal fun interface InternalListener {
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
@@ -11,7 +11,9 @@ package com.example.smoke
 /**
  * Observer interface for monitoring changes in thermometer ("Observer of subject").
  */
-interface TemperatureObserver {
+fun interface TemperatureObserver {
+
+
 
     fun onTemperatureUpdate(thermometer: Thermometer) : Unit
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
@@ -38,7 +38,7 @@ class OuterClass : NativeBase {
         }
     }
 
-    interface InnerInterface {
+    fun interface InnerInterface {
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
@@ -38,7 +38,7 @@ class OuterClassWithInheritance : ParentClass {
         }
     }
 
-    interface InnerInterface {
+    fun interface InnerInterface {
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-interface OuterInterface {
+fun interface OuterInterface {
     class InnerClass : NativeBase {
 
 
@@ -37,7 +37,7 @@ interface OuterInterface {
         }
     }
 
-    interface InnerInterface {
+    fun interface InnerInterface {
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -104,7 +104,7 @@ class OuterStruct {
         }
     }
 
-    interface InnerInterface {
+    fun interface InnerInterface {
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsInKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsInKotlin.kt
@@ -8,7 +8,9 @@
 package com.example.smoke
 
 
-interface SkipTagsInKotlin {
+fun interface SkipTagsInKotlin {
+
+
 
     fun dontSkipTagged() : Unit
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterface.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal interface InternalInterface {
+internal fun interface InternalInterface {
 
 
 


### PR DESCRIPTION
---------- Motivation ----------
When the generated Java code is accessed from Kotlin
then single method interfaces are by default functional.
    
Because of that when anybody tries to switch from Java
to Kotlin generated code, he/she may encounter the following
error: single method interfaces in Kotlin are not annotated
as functional by default.

---------- Solution ----------
Implemented the new predicate, which checks if the interface
can be annotated as functional and introduced the usage of
the new predicate in mustache template, which is used to generate
the Kotlin interfaces.

In Kotlin, a functional interface:
 - can have only one non-static function
 - cannot have non-static properties
 - can have multiple static functions/properties

This commit also introduces functional test, which was used to
showcase the compilation failure.