### PR TITLE
C++: allow iterating over unique enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+ * C++: introduced the new 'EnumValues' attribute, which allows uses to instruct the C++ generator to create helper function for the given enumeration. The mentioned function returns an array of unique enumerator values.
+
 ## 14.1.1
 Release date 2026-03-03
  * C++: fixed a bug related to redundant 'using' statements generation for derived classes. We generate using statment to avoid warning/error related to method shadowing, when base and derived classes have method overload with the same name.

--- a/docs/lime_attributes.md
+++ b/docs/lime_attributes.md
@@ -214,6 +214,7 @@ quotes need to be backslash-escaped, as in the example.
 in C++ generated code. For example, `@Cpp(Type="std::chrono::steady_clock::time_point") Date` will use monotonic clock
 time point type, instead of the system clock time point type which is used by default.
 * **ToString**: marks an enumeration to have a helper `to_string()` function generated, mapping the enum to string.
+* **EnumValues**: marks an enumeration to have a helper `<ENUM_NAME>_enumerators()` function generated. It returns array of unique enum values.
 * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in C++. Can be applied to
 `field constuctor` or `const` elements only. Optionally, if custom tag is specified, the element is only skipped if
 that tag was defined (see `@Skip` above).

--- a/functional-tests/functional/cpp/tests/EnumTest.cpp
+++ b/functional-tests/functional/cpp/tests/EnumTest.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/EnumWithToStringHelper.h"
+#include "test/EnumWithAccessibleValues.h"
 
 #include <gmock/gmock.h>
 
@@ -32,6 +33,21 @@ TEST( EnumTest, to_string_returns_proper_values )
 {
     EXPECT_EQ(to_string(EnumWithToStringHelper::FIRST), "EnumWithToStringHelper::FIRST");
     EXPECT_EQ(to_string(EnumWithToStringHelper::SECOND), "EnumWithToStringHelper::SECOND");
+}
+
+TEST( EnumTest, enum_values_attribute )
+{
+    // Only unique values are returned.
+    const auto enumerators = EnumWithAccessibleValues_enumerators();
+    ASSERT_EQ(3u, enumerators.size());
+
+    // Values have the same order as defined.
+    EXPECT_EQ(EnumWithAccessibleValues::FOO, enumerators[0]);
+    EXPECT_EQ(EnumWithAccessibleValues::BAR, enumerators[1]);
+    EXPECT_EQ(EnumWithAccessibleValues::BAZ, enumerators[2]);
+
+    // Aliasing enumerator is present -- because its original version is in the container.
+    EXPECT_EQ(EnumWithAccessibleValues::FOO_ALIAS, enumerators[0]);
 }
 
 }  // test

--- a/functional-tests/functional/input/lime/Enums.lime
+++ b/functional-tests/functional/input/lime/Enums.lime
@@ -68,3 +68,11 @@ enum EnumWithToStringHelper {
     FIRST,
     SECOND
 }
+
+@Cpp(EnumValues)
+enum EnumWithAccessibleValues {
+    FOO,
+    BAR,
+    BAZ,
+    FOO_ALIAS = FOO
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppIncludeResolver.kt
@@ -24,6 +24,7 @@ import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.model.lime.LimeAttributeType.ASYNC
 import com.here.gluecodium.model.lime.LimeAttributeType.CPP
 import com.here.gluecodium.model.lime.LimeAttributeType.OPTIMIZED
+import com.here.gluecodium.model.lime.LimeAttributeValueType.ENUM_VALUES
 import com.here.gluecodium.model.lime.LimeAttributeValueType.TO_STRING
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
@@ -72,7 +73,8 @@ internal class CppIncludeResolver(
             is LimeLambda -> cppIncludesCache.resolveIncludes(limeElement) + CppLibraryIncludes.FUNCTIONAL
             is LimeNamedElement ->
                 cppIncludesCache.resolveIncludes(limeElement) +
-                    listOfNotNull(CppLibraryIncludes.STRING_VIEW.takeIf { limeElement.attributes.have(CPP, TO_STRING) })
+                    listOfNotNull(CppLibraryIncludes.STRING_VIEW.takeIf { limeElement.attributes.have(CPP, TO_STRING) }) +
+                    listOfNotNull(CppLibraryIncludes.ARRAY.takeIf { limeElement.attributes.have(CPP, ENUM_VALUES) })
             else -> emptyList()
         }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppLibraryIncludes.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppLibraryIncludes.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 object CppLibraryIncludes {
+    val ARRAY = Include.createSystemInclude("array")
     val INT_TYPES = Include.createSystemInclude("cstdint")
     val MAP = Include.createSystemInclude("unordered_map")
     val MEMORY = Include.createSystemInclude("memory")

--- a/gluecodium/src/main/resources/templates/cpp/CppEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppEnumeration.mustache
@@ -31,4 +31,9 @@ enum class {{>cpp/CppAttributesInline}}{{resolveName}} {
 std::string_view
 {{>cpp/CppExportMacro}}to_string({{resolveName}} enumeration);
 {{/if}}
+
+{{#if attributes.cpp.enumvalues}}
+std::array<{{resolveName}}, {{uniqueEnumerators.size}}>
+{{>cpp/CppExportMacro}}{{resolveName}}_enumerators();
+{{/if}}
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/cpp/CppEnumerationImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppEnumerationImpl.mustache
@@ -40,3 +40,18 @@ static_assert(
     return "<unknown>";
   }
 {{/if}}
+
+{{#if attributes.cpp.enumvalues}}
+  std::array<{{resolveName}}, {{uniqueEnumerators.size}}>
+  {{resolveName}}_enumerators() {
+    return std::array<{{resolveName}}, {{uniqueEnumerators.size}}>{
+      {
+{{#set thisEnum=this}}{{#thisEnum}}{{!!
+}}{{#uniqueEnumerators}}
+        {{resolveName thisEnum}}::{{resolveName}}{{#if iter.hasNext}},{{/if}}
+{{/uniqueEnumerators}}{{!!
+}}{{/thisEnum}}{{/set}}
+      }
+    };
+  }
+{{/if}}

--- a/gluecodium/src/test/resources/smoke/enums/input/Enums.lime
+++ b/gluecodium/src/test/resources/smoke/enums/input/Enums.lime
@@ -64,3 +64,11 @@ enum EnumWithToStringHelper {
     FIRST,
     SECOND
 }
+
+@Cpp(EnumValues)
+enum EnumWithAccessibleValues {
+    FOO,
+    BAR,
+    BAZ,
+    FOO_ALIAS = FOO
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAccessibleValues.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAccessibleValues.h
@@ -1,0 +1,26 @@
+// -------------------------------------------------------------------------------------------------
+//
+
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <array>
+#include <cstdint>
+
+namespace smoke {
+enum class EnumWithAccessibleValues {
+    FOO,
+    BAR,
+    BAZ,
+    FOO_ALIAS = ::smoke::EnumWithAccessibleValues::FOO
+};
+
+
+std::array<EnumWithAccessibleValues, 3>
+_GLUECODIUM_CPP_EXPORT EnumWithAccessibleValues_enumerators();
+
+
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/src/smoke/EnumWithAccessibleValues.cpp
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/src/smoke/EnumWithAccessibleValues.cpp
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------------
+//
+
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "smoke/EnumWithAccessibleValues.h"
+
+namespace smoke {
+
+
+  std::array<EnumWithAccessibleValues, 3>
+  EnumWithAccessibleValues_enumerators() {
+    return std::array<EnumWithAccessibleValues, 3>{
+      {
+        EnumWithAccessibleValues::FOO,
+        EnumWithAccessibleValues::BAR,
+        EnumWithAccessibleValues::BAZ
+      }
+    };
+  }
+
+}
+

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -333,6 +333,7 @@ internal object AntlrLimeConverter {
             "Const" -> LimeAttributeValueType.CONST
             "Default" -> LimeAttributeValueType.DEFAULT
             "EnableIf" -> LimeAttributeValueType.ENABLE_IF
+            "EnumValues" -> LimeAttributeValueType.ENUM_VALUES
             "FullName" -> LimeAttributeValueType.FULL_NAME
             "FunctionName" -> LimeAttributeValueType.FUNCTION_NAME
             "Internal" -> LimeAttributeValueType.INTERNAL

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -26,6 +26,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     CONST("Const"),
     DEFAULT("Default"),
     ENABLE_IF("EnableIf"),
+    ENUM_VALUES("EnumValues"),
     FULL_NAME("FullName"),
     FUNCTION_NAME("FunctionName"),
     FUNCTION("Function"),


### PR DESCRIPTION
---------- Motivation ----------
There were a few requests in the past to provide the means for
users of the generated code to iterate over enumeration values.

---------- Solution ----------
Introduced a new cpp-specific attribute in LIME language called 'EnumValues'.
When LIME enumeration is annotated with it, then C++ generator creates additional
helper function that returns the array of unique enumerators. It is achieved via the new
mustache templates. The change implements smoke and functional tests to confirm
that the new functionality works as expected.

For the following input:
```
@Cpp(EnumValues)
enum EnumWithAccessibleValues {
    FOO,
    BAR,
    BAZ,
    FOO_ALIAS = FOO
}
```

The additional function is generated:
```
std::array<EnumWithAccessibleValues, 3>
EnumWithAccessibleValues_enumerators();
```