### PR TITLE
CI: ensure that macOS runner is x64

### DIFF
--- a/.github/workflows/cmake-tests-macos.yml
+++ b/.github/workflows/cmake-tests-macos.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   cmake-tests-ios:
     name: CMake toolchain tests for iOS
-    runs-on: macos-14
+    runs-on: macos-15-intel
 
     steps:
       - uses: actions/checkout@v2
@@ -36,6 +36,7 @@ jobs:
       - name: Build and run functional tests
         run: |
           export CTEST_PARALLEL_LEVEL=6
+          export JAVA_HOME="$JAVA_HOME/Contents/Home"
           ./gradlew publishToMavenLocal
           cd cmake
           GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 cmake -P run-cmake-unit-test.cmake

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -260,7 +260,7 @@ jobs:
 
   swift-mac:
     name: Swift on MacOS
-    runs-on: macos-14
+    runs-on: macos-15-intel
 
     steps:
       - uses: actions/checkout@v2
@@ -285,6 +285,7 @@ jobs:
         run: |
           export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
           export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+          export JAVA_HOME="$JAVA_HOME/Contents/Home"
           ./scripts/build-swift-functional --buildGluecodium
         working-directory: functional-tests
       - name: Removing build folder
@@ -295,10 +296,12 @@ jobs:
         run: |
           export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
           export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+          export JAVA_HOME="$JAVA_HOME/Contents/Home"
           ./scripts/build-swift-namerules --publish
         working-directory: functional-tests
       - name: Build examples
         run: |
+          export JAVA_HOME="$JAVA_HOME/Contents/Home"
           mkdir build_example_calculator
           cmake -B build_example_calculator examples/calculator -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_SYSTEM_NAME=iOS
           cmake --build build_example_calculator


### PR DESCRIPTION
---------- Motivation ----------
The runner images for 'macOS 13' had the following convention regarding the hardware architecture:
 - 'macos-13' --> x64
 - 'macos-13-xlarge' --> arm64

It has been different since 'macOS 14':
 - 'macos-14' --> arm64
 - 'macos-14-large' --> x64
 - 'macos-15' --> arm64
 - 'macos-15-intel' and 'macos-15-large' --> x64

In January 2026 the runner image was updated from 'macos-13' to 'macos-14' because the older
version was deprecated. It was not checked that the runner architecture is different -- the change
in runner naming convention was not expected.

Recently the job, which executes functional tests for Swift generated code on macOS started to fail.
The installation of Java did not work properly. The investigation revealed that Java was installed for
x64 instead of arm64. The action used to install Java cannot be configured for arm.

---------- Solution ----------
Introduced the usage of 'macos-15-intel' runner to ensure that the hardware architecture of the runner is x64.
Moreover, adjusted the environment variable to avoid problems with 'JAVA_HOME' variable.