### PR TITLE
docs: document all-uppercase acronym transformation

### DIFF
--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -233,3 +233,52 @@ error.suffix=Exception
 join.infix=_
 
 ```
+
+Handling all-uppercase acronyms
+-------------------------------
+
+### Known limitation
+
+All-uppercase acronyms in LimeIDL names are converted to mixed case when transformed to camelCase format.
+
+**Example:**
+* Input: `FACTORY` 
+* Output: `Factory` (when using `UpperCamelCase`)
+* Output: `factory` (when using `lowerCamelCase`)
+
+### Root cause
+
+Name transformation logic recognizes common casing patterns (existing camelCase, snake_case with delimiters). Single-word all-uppercase strings do not match any recognized pattern and are treated as generic strings: they are lowercased completely, then the appropriate case style is applied (first letter capitalized for `UpperCamelCase`, kept lowercase for `lowerCamelCase`).
+
+This behavior preserves consistency for `UPPER_SNAKE_CASE` inputs (e.g., `SOME_CONSTANT` → `someConstant`).
+
+### Workaround: Use name attributes
+
+To preserve all-uppercase naming for acronyms, use platform-specific `Name` attributes in LIME:
+
+**Java / Kotlin:**
+```
+@Java(Name = "FACTORY")
+@Kotlin(Name = "FACTORY")
+type FACTORY {
+    // fields
+}
+```
+
+**Swift:**
+```
+@Swift(Name = "FACTORY")
+type FACTORY {
+    // fields
+}
+```
+
+**Dart:**
+```
+@Dart("FACTORY")
+type FACTORY {
+    // fields
+}
+```
+
+Attributes override name transformation rules completely, allowing you to enforce exact names regardless of configured naming conventions.

--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -260,7 +260,7 @@ To preserve all-uppercase naming for acronyms, use platform-specific `Name` attr
 ```
 @Java(Name = "FACTORY")
 @Kotlin(Name = "FACTORY")
-type FACTORY {
+class FACTORY {
     // fields
 }
 ```
@@ -268,7 +268,7 @@ type FACTORY {
 **Swift:**
 ```
 @Swift(Name = "FACTORY")
-type FACTORY {
+class FACTORY {
     // fields
 }
 ```
@@ -276,7 +276,7 @@ type FACTORY {
 **Dart:**
 ```
 @Dart("FACTORY")
-type FACTORY {
+class FACTORY {
     // fields
 }
 ```


### PR DESCRIPTION
## Uppercase acronyms in name transformation
Problem: All-uppercase acronyms like `FACTORY` are converted to mixed case (`Factory`) when transformed to camelCase format. This limitation affects users defining single-word uppercase identifiers in LIME.

Solution: Documented the behavior with:
- Root cause: Recognition logic treats all-uppercase single words as generic strings, not recognized patterns
- Workaround: Platform-specific `Name` attributes override transformation rules completely
  - `@Java(Name = "FACTORY")`, `@Kotlin(Name = "FACTORY")`, `@Swift(Name = "FACTORY")`, `@Dart("FACTORY")`