### PR TITLE
docs: add @AsyncDecorator changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  * C++: introduced the new 'EnumValues' attribute, which allows uses to instruct the C++ generator to create helper function for the given enumeration. The mentioned function returns an array of unique enumerator values.
+ * Kotlin: added `@AsyncDecorator` attribute for generating Kotlin coroutine `suspend` extension functions from callback-based asynchronous functions. This allows Kotlin consumers to call async APIs using idiomatic coroutines instead of raw callbacks. Supports result/error mapping, cancellation via `@AsyncTaskHandle`, and custom wrapper naming via `@AsyncDecorator(Name = "...")`.
 
 ## 14.1.1
 Release date 2026-03-03


### PR DESCRIPTION
## Summary
- Add changelog entry for the `@AsyncDecorator` feature under the "Unreleased" section.

## Context
PR #1812 merged the feature but did not include a changelog entry. This is needed before the next release is cut.